### PR TITLE
build: remove publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "src"
   ],
   "scripts": {
-    "publish": "npm run clean && npm run build && npm publish",
     "clean": "rm -rf tsconfig.tsbuildinfo ./dist",
     "build": "npm run build:types && npm run build:tsup",
     "build:tsup": "tsup ./src/index.ts --format esm,cjs --sourcemap",


### PR DESCRIPTION
- To avoid run publish twice, we remove the publish script.