### PR TITLE
Rename the type of support coins

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Remove the `.skip` to unskip the test.
 
 - Setup the network
 
-  ````typescript
+  ```typescript
   const NETWORK: NetworkType = 'testnet';
-  ````
+  ```
 
 - Run the test
 
@@ -81,138 +81,138 @@ Remove the `.skip` to unskip the test.
 
 - Get Market Query Data
 
-  ````typescript
-    it('Should get market query data', async () => {
-      const marketData = await client.queryMarket();
-      console.info('marketData:', marketData);
-      expect(!!marketData).toBe(true);
-    });
-  ````
-    
+  ```typescript
+  it('Should get market query data', async () => {
+    const marketData = await client.queryMarket();
+    console.info('marketData:', marketData);
+    expect(!!marketData).toBe(true);
+  });
+  ```
+
 - Open Obligation Account
 
-  ````typescript
-    it('Should open a obligation account', async () => {
-      const openObligationResult = await client.openObligation();
-      console.info('openObligationResult:', openObligationResult);
-      expect(openObligationResult.effects.status.status).toEqual('success');
-    });
-    ````
+  ```typescript
+  it('Should open a obligation account', async () => {
+    const openObligationResult = await client.openObligation();
+    console.info('openObligationResult:', openObligationResult);
+    expect(openObligationResult.effects.status.status).toEqual('success');
+  });
+  ```
 
 - Get Obligations and Query Data
 
-  ````typescript
-    it('Should get obligations and its query data', async () => {
-      const obligations = await client.getObligations();
-      console.info('obligations', obligations);
-      for (const { id } of obligations) {
-        const obligationData = await client.queryObligation(id);
-        console.info('id:', id);
-        console.info('obligationData:');
-        console.dir(obligationData, { depth: null, colors: true });
-        expect(!!obligationData).toBe(true);
-      }
-    });
-  ````
+  ```typescript
+  it('Should get obligations and its query data', async () => {
+    const obligations = await client.getObligations();
+    console.info('obligations', obligations);
+    for (const { id } of obligations) {
+      const obligationData = await client.queryObligation(id);
+      console.info('id:', id);
+      console.info('obligationData:');
+      console.dir(obligationData, { depth: null, colors: true });
+      expect(!!obligationData).toBe(true);
+    }
+  });
+  ```
 
 - Get Test Coin
 
-  ````typescript
-    it('Should get test coin', async () => {
-      const mintTestCoinResult = await client.mintTestCoin('btc', 10 ** 11);
-      console.info('mintTestCoinResult:', mintTestCoinResult);
-      expect(mintTestCoinResult.effects.status.status).toEqual('success');
-    });
-  ````
+  ```typescript
+  it('Should get test coin', async () => {
+    const mintTestCoinResult = await client.mintTestCoin('btc', 10 ** 11);
+    console.info('mintTestCoinResult:', mintTestCoinResult);
+    expect(mintTestCoinResult.effects.status.status).toEqual('success');
+  });
+  ```
 
 - Deposit Collateral
 
-  ````typescript
-    it('Should depoist collateral successfully', async () => {
-      const obligations = await client.getObligations();
-      const depositCollateralResult = await client.depositCollateral(
-        'btc',
-        10 ** 11,
-        true,
-        obligations[0]?.id
-      );
-      console.info('depositCollateralResult:', depositCollateralResult);
-      expect(depositCollateralResult.effects.status.status).toEqual('success');
-    });
-  ````
-    
+  ```typescript
+  it('Should depoist collateral successfully', async () => {
+    const obligations = await client.getObligations();
+    const depositCollateralResult = await client.depositCollateral(
+      'btc',
+      10 ** 11,
+      true,
+      obligations[0]?.id
+    );
+    console.info('depositCollateralResult:', depositCollateralResult);
+    expect(depositCollateralResult.effects.status.status).toEqual('success');
+  });
+  ```
+
 - Withdraw Collateral
 
-  ````typescript
-    it('Should withdraw collateral successfully', async () => {
-      const obligations = await client.getObligations();
-      if (obligations.length === 0) throw Error('Obligation is required.');
-      const withdrawCollateralResult = await client.withdrawCollateral(
-        'eth',
-        10 ** 10,
-        true,
-        obligations[0].id,
-        obligations[0].keyId
-      );
-      console.info('withdrawCollateralResult:', withdrawCollateralResult);
-      expect(withdrawCollateralResult.effects.status.status).toEqual('success');
-    });
-  ````
-    
+  ```typescript
+  it('Should withdraw collateral successfully', async () => {
+    const obligations = await client.getObligations();
+    if (obligations.length === 0) throw Error('Obligation is required.');
+    const withdrawCollateralResult = await client.withdrawCollateral(
+      'eth',
+      10 ** 10,
+      true,
+      obligations[0].id,
+      obligations[0].keyId
+    );
+    console.info('withdrawCollateralResult:', withdrawCollateralResult);
+    expect(withdrawCollateralResult.effects.status.status).toEqual('success');
+  });
+  ```
+
 - Deposit Asset
 
-  ````typescript
-    it('Should depoist asset successfully', async () => {
-      const depositResult = await client.deposit('usdc', 10 ** 10, true);
-      console.info('depositResult:', depositResult);
-      expect(depositResult.effects.status.status).toEqual('success');
-    });
-  ````
-    
+  ```typescript
+  it('Should depoist asset successfully', async () => {
+    const depositResult = await client.deposit('usdc', 10 ** 10, true);
+    console.info('depositResult:', depositResult);
+    expect(depositResult.effects.status.status).toEqual('success');
+  });
+  ```
+
 - Withdraw Asset
 
-  ````typescript
-    it('Should withdraw asset successfully', async () => {
-      const withdrawResult = await client.withdraw('usdc', 5 * 10 ** 8, true);
-      console.info('withdrawResult:', withdrawResult);
-      expect(withdrawResult.effects.status.status).toEqual('success');
-    });
-  ````
-    
+  ```typescript
+  it('Should withdraw asset successfully', async () => {
+    const withdrawResult = await client.withdraw('usdc', 5 * 10 ** 8, true);
+    console.info('withdrawResult:', withdrawResult);
+    expect(withdrawResult.effects.status.status).toEqual('success');
+  });
+  ```
+
 - Borrow Asset
 
-  ````typescript
-    it('Should borrow asset successfully', async () => {
-      const obligations = await client.getObligations();
-      if (obligations.length === 0) throw Error('Obligation is required.');
-      const borrowResult = await client.borrow(
-        'usdc',
-        10 ** 9,
-        true,
-        obligations[0].id,
-        obligations[0].keyId
-      );
-      console.info('borrowResult:', borrowResult);
-      expect(borrowResult.effects.status.status).toEqual('success');
-    });
-  ````
-    
+  ```typescript
+  it('Should borrow asset successfully', async () => {
+    const obligations = await client.getObligations();
+    if (obligations.length === 0) throw Error('Obligation is required.');
+    const borrowResult = await client.borrow(
+      'usdc',
+      10 ** 9,
+      true,
+      obligations[0].id,
+      obligations[0].keyId
+    );
+    console.info('borrowResult:', borrowResult);
+    expect(borrowResult.effects.status.status).toEqual('success');
+  });
+  ```
+
 - Repay Asset
 
-  ````typescript
-    it('Should repay asset successfully', async () => {
-      const obligations = await client.getObligations();
-      if (obligations.length === 0) throw Error('Obligation is required.');
-      const repayResult = await client.repay(
-        'usdc',
-        10 ** 8,
-        true,
-        obligations[0].id
-      );
-      console.info('repayResult:', repayResult);
-      expect(repayResult.effects.status.status).toEqual('success');
-    });
-  ````
+  ```typescript
+  it('Should repay asset successfully', async () => {
+    const obligations = await client.getObligations();
+    if (obligations.length === 0) throw Error('Obligation is required.');
+    const repayResult = await client.repay(
+      'usdc',
+      10 ** 8,
+      true,
+      obligations[0].id
+    );
+    console.info('repayResult:', repayResult);
+    expect(repayResult.effects.status.status).toEqual('success');
+  });
+  ```
 
 ## Use address manager
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
     "dotenv": "^16.0.3",
-    "eslint": "^8.40.0",
+    "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,22 +29,22 @@ devDependencies:
     version: 20.2.1
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.59.6
-    version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4)
+    version: 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.41.0)(typescript@5.0.4)
   '@typescript-eslint/parser':
     specifier: ^5.59.6
-    version: 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+    version: 5.59.6(eslint@8.41.0)(typescript@5.0.4)
   dotenv:
     specifier: ^16.0.3
     version: 16.0.3
   eslint:
-    specifier: ^8.40.0
-    version: 8.40.0
+    specifier: ^8.41.0
+    version: 8.41.0
   eslint-config-prettier:
     specifier: ^8.8.0
-    version: 8.8.0(eslint@8.40.0)
+    version: 8.8.0(eslint@8.41.0)
   eslint-plugin-prettier:
     specifier: ^4.2.1
-    version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.40.0)(prettier@2.8.8)
+    version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.41.0)(prettier@2.8.8)
   husky:
     specifier: ^8.0.3
     version: 8.0.3
@@ -497,13 +497,13 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.40.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.41.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.40.0
+      eslint: 8.41.0
       eslint-visitor-keys: 3.4.1
     dev: true
 
@@ -529,8 +529,8 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.40.0:
-    resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
+  /@eslint/js@8.41.0:
+    resolution: {integrity: sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -751,7 +751,7 @@ packages:
       '@types/node': 20.2.1
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.41.0)(typescript@5.0.4):
     resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -763,12 +763,12 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
       '@typescript-eslint/scope-manager': 5.59.6
-      '@typescript-eslint/type-utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
       debug: 4.3.4
-      eslint: 8.40.0
+      eslint: 8.41.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -779,7 +779,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@5.59.6(eslint@8.41.0)(typescript@5.0.4):
     resolution: {integrity: sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -793,7 +793,7 @@ packages:
       '@typescript-eslint/types': 5.59.6
       '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
       debug: 4.3.4
-      eslint: 8.40.0
+      eslint: 8.41.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -807,7 +807,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.59.6(eslint@8.41.0)(typescript@5.0.4):
     resolution: {integrity: sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -818,9 +818,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.40.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.41.0)(typescript@5.0.4)
       debug: 4.3.4
-      eslint: 8.40.0
+      eslint: 8.41.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -853,19 +853,19 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.6(eslint@8.40.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.59.6(eslint@8.41.0)(typescript@5.0.4):
     resolution: {integrity: sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.40.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
       '@types/json-schema': 7.0.11
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
       '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.0.4)
-      eslint: 8.40.0
+      eslint: 8.41.0
       eslint-scope: 5.1.1
       semver: 7.5.0
     transitivePeerDependencies:
@@ -1633,16 +1633,16 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier@8.8.0(eslint@8.40.0):
+  /eslint-config-prettier@8.8.0(eslint@8.41.0):
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.40.0
+      eslint: 8.41.0
     dev: true
 
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.40.0)(prettier@2.8.8):
+  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.41.0)(prettier@2.8.8):
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -1653,8 +1653,8 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 8.40.0
-      eslint-config-prettier: 8.8.0(eslint@8.40.0)
+      eslint: 8.41.0
+      eslint-config-prettier: 8.8.0(eslint@8.41.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
     dev: true
@@ -1680,15 +1680,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.40.0:
-    resolution: {integrity: sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==}
+  /eslint@8.41.0:
+    resolution: {integrity: sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.40.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
       '@eslint-community/regexpp': 4.5.1
       '@eslint/eslintrc': 2.0.3
-      '@eslint/js': 8.40.0
+      '@eslint/js': 8.41.0
       '@humanwhocodes/config-array': 0.11.8
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -1708,13 +1708,12 @@ packages:
       find-up: 5.0.0
       glob-parent: 6.0.2
       globals: 13.20.0
-      grapheme-splitter: 1.0.4
+      graphemer: 1.4.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-sdsl: 4.4.0
       js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
@@ -2043,6 +2042,10 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
+  /graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
+
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -2341,10 +2344,6 @@ packages:
   /joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-    dev: true
-
-  /js-sdsl@4.4.0:
-    resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
     dev: true
 
   /js-string-escape@1.0.1:

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -5,9 +5,9 @@ import { ScallopUtils } from './scallopUtils';
 import { ScallopTxBuilder } from './txBuilder';
 import type {
   ScallopParams,
-  SupportAssetCoinType,
-  SupportCollateralCoinType,
-  SupportCoinType,
+  SupportAssetCoins,
+  SupportCollateralCoins,
+  SupportCoins,
   MarketInterface,
   ObligationInterface,
 } from '../types';
@@ -138,7 +138,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async depositCollateral(
-    coinName: SupportCollateralCoinType,
+    coinName: SupportCollateralCoins,
     amount: number,
     sign: boolean = true,
     obligationId?: string,
@@ -202,7 +202,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async withdrawCollateral(
-    coinName: SupportCollateralCoinType,
+    coinName: SupportCollateralCoins,
     amount: number,
     sign: boolean = true,
     obligationId: string,
@@ -231,7 +231,7 @@ export class ScallopClient {
     for (const updateCoinType of updateCoinTypes) {
       const updateCoin = updateCoinType
         .split('::')[2]
-        .toLowerCase() as SupportCoinType;
+        .toLowerCase() as SupportCoins;
 
       const [vaaFromFeeId] = await this._utils.getVaas([
         this.address.get(`core.coins.${updateCoin}.oracle.pyth.feed`),
@@ -284,7 +284,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async deposit(
-    coinName: SupportAssetCoinType,
+    coinName: SupportAssetCoins,
     amount: number,
     sign: boolean = true,
     walletAddress?: string
@@ -326,7 +326,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async withdraw(
-    coinName: SupportAssetCoinType,
+    coinName: SupportAssetCoins,
     amount: number,
     sign: boolean = true,
     walletAddress?: string
@@ -384,7 +384,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async borrow(
-    coinName: SupportAssetCoinType,
+    coinName: SupportAssetCoins,
     amount: number,
     sign: boolean = true,
     obligationId: string,
@@ -414,7 +414,7 @@ export class ScallopClient {
     for (const updateCoinType of updateCoinTypes) {
       const updateCoin = updateCoinType
         .split('::')[2]
-        .toLowerCase() as SupportCoinType;
+        .toLowerCase() as SupportCoins;
 
       const [vaaFromFeeId] = await this._utils.getVaas([
         this.address.get(`core.coins.${updateCoin}.oracle.pyth.feed`),
@@ -468,7 +468,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async repay(
-    coinName: SupportAssetCoinType,
+    coinName: SupportAssetCoins,
     amount: number,
     sign: boolean = true,
     obligationId: string,
@@ -515,7 +515,7 @@ export class ScallopClient {
    * @return Transaction block response or transaction block
    */
   public async mintTestCoin(
-    coinName: Exclude<SupportCoinType, 'sui'>,
+    coinName: Exclude<SupportCoins, 'sui'>,
     amount: number,
     sign: boolean = true,
     receiveAddress?: string

--- a/src/models/txBuilder.ts
+++ b/src/models/txBuilder.ts
@@ -7,7 +7,7 @@ import {
 import { SuiTxBlock } from '@scallop-io/sui-kit';
 import { Buffer } from 'node:buffer';
 import { SUI_COIN_TYPE_ARG_REGEX } from '../constants';
-import type { SupportCoinType } from '../types';
+import type { SupportCoins } from '../types';
 
 /**
  * it provides methods for build transaction.
@@ -513,7 +513,7 @@ export class ScallopTxBuilder {
   public mintTestCoin(
     packageId: string,
     treasuryId: TransactionArgument | string,
-    coinName: SupportCoinType,
+    coinName: SupportCoins,
     amount: number
   ) {
     const target = `${packageId}::${coinName}::mint`;
@@ -536,7 +536,7 @@ export class ScallopTxBuilder {
   public mintTestCoinEntry(
     packageId: string,
     treasuryId: TransactionArgument | string,
-    coinName: SupportCoinType,
+    coinName: SupportCoins,
     amount: number,
     recipient: string
   ) {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -5,10 +5,9 @@ import {
   SUPPORT_PACKAGES,
 } from '../constants/common';
 
-export type SupportAssetCoinType = (typeof SUPPORT_ASSET_COINS)[number];
-export type SupportCollateralCoinType =
-  (typeof SUPPORT_COLLATERAL_COINS)[number];
-export type SupportCoinType = SupportAssetCoinType | SupportCollateralCoinType;
+export type SupportAssetCoins = (typeof SUPPORT_ASSET_COINS)[number];
+export type SupportCollateralCoins = (typeof SUPPORT_COLLATERAL_COINS)[number];
+export type SupportCoins = SupportAssetCoins | SupportCollateralCoins;
 export type SupportOracleType = (typeof SUPPORT_ORACLES)[number];
 export type SupportPackageType = (typeof SUPPORT_PACKAGES)[number];
 
@@ -93,7 +92,7 @@ export interface AddressesInterface {
     coinDecimalsRegistry: string;
     coins: Partial<
       Record<
-        SupportCoinType,
+        SupportCoins,
         {
           id: string;
           treasury: string;


### PR DESCRIPTION
Change from ending with `CoinType` to `Coins`, to avoid confusion with the types of coin objects.