### PR TITLE
fix: duplicated coin type name

### DIFF
--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -3,6 +3,7 @@ import {
   TransactionArgument,
   SUI_TYPE_ARG,
   SUI_FRAMEWORK_ADDRESS,
+  normalizeStructTag,
 } from '@mysten/sui.js';
 import { SuiKit } from '@scallop-io/sui-kit';
 import { ScallopAddress } from './scallopAddress';
@@ -226,7 +227,7 @@ export class ScallopClient {
     const coinPackageId = this.address.get(`core.coins.${coinName}.id`);
     const coinType =
       coinName === 'sui'
-        ? SUI_TYPE_ARG
+        ? normalizeStructTag(SUI_TYPE_ARG)
         : this._utils.parseCoinTpe(coinPackageId, coinName);
 
     // update prices
@@ -406,7 +407,7 @@ export class ScallopClient {
     const coinPackageId = this.address.get(`core.coins.${coinName}.id`);
     const coinType =
       coinName === 'sui'
-        ? SUI_TYPE_ARG
+        ? normalizeStructTag(SUI_TYPE_ARG)
         : this._utils.parseCoinTpe(coinPackageId, coinName);
 
     // update prices


### PR DESCRIPTION
## Description
When updating the price in `xOracle` obj, it called the update instruction **2 times** for SUI coins.
Because SUI coin types can be written as `0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI` or `0x2::sui::SUI`.
While `Set` see it as two different values, the `updateCoinTypes` can contain those two values.
Hence we convert the `0x2::sui::SUI` as `0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI` using `normalizeStructTag` function.