### PR TITLE
feat: allow passing addressId as argument in Scallop class

### DIFF
--- a/src/models/scallop.ts
+++ b/src/models/scallop.ts
@@ -27,7 +27,7 @@ export class Scallop {
     this.params = params;
     this.suiKit = new SuiKit(params);
     this.address = new ScallopAddress({
-      id: ADDRESSES_ID,
+      id: params?.addressesId || ADDRESSES_ID,
       network: params?.networkType,
     });
   }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -7,7 +7,9 @@ import type { SuiKitParams, NetworkType } from '@scallop-io/sui-kit';
 export type ScallopClientFnReturnType<T extends boolean> = T extends true
   ? SuiTransactionBlockResponse
   : TransactionBlock;
-export type ScallopParams = {} & SuiKitParams;
+export type ScallopParams = {
+  addressesId?: string;
+} & SuiKitParams;
 export type ScallopAddressParams = {
   id: string;
   auth?: string;


### PR DESCRIPTION
## Description
In most cases, when initializing `Scallop` object using the defined constant of `ADDRESSES_ID` to define the `ScallopAddresses` object is all we need. but to make it more dynamic and cover a case when we want to use other addresses, we need to allow passing `addressesId` to replace the default id.