### PR TITLE
feat: add protocol object id constant

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -2,6 +2,9 @@ export const API_BASE_URL = 'https://sui.api.scallop.io';
 
 export const ADDRESSES_ID = '6462a088a7ace142bb6d7e9b';
 
+export const PROTOCOL_OBJECT_ID =
+  '0xefe8b36d5b2e43728cc323298626b83177803521d195cfb11e15b910e892fddf';
+
 export const SUPPORT_ASSET_COINS = [
   'eth',
   'btc',

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -82,7 +82,7 @@ export class ScallopClient {
    */
   async getObligations(ownerAddress?: string) {
     const owner = ownerAddress || this.walletAddress;
-    return getObligations(owner, this.address, this.suiKit);
+    return getObligations(owner, this.suiKit);
   }
 
   /**

--- a/src/models/scallopUtils.ts
+++ b/src/models/scallopUtils.ts
@@ -5,6 +5,7 @@ import {
 } from '@mysten/sui.js';
 import { SuiKit } from '@scallop-io/sui-kit';
 import { PriceServiceConnection } from '@pythnetwork/price-service-client';
+import { PROTOCOL_OBJECT_ID } from '../constants/common';
 import type { ScallopParams, SupportCoins } from '../types';
 
 /**
@@ -138,20 +139,15 @@ export class ScallopUtils {
    * @description Handle market coin types.
    *
    * @param coinPackageId Package id of coin.
-   * @param protocolPkgId Package id of protocol.
    * @param coinName specific support coin name.
    *
    * @return marketCoinType.
    */
-  public parseMarketCoinType(
-    coinPackageId: string,
-    protocolPkgId: string,
-    coinName: string
-  ) {
+  public parseMarketCoinType(coinPackageId: string, coinName: string) {
     const coinType = this.parseCoinType(
       coinName === 'sui' ? SUI_FRAMEWORK_ADDRESS : coinPackageId,
       coinName
     );
-    return `${protocolPkgId}::reserve::MarketCoin<${coinType}>`;
+    return `${PROTOCOL_OBJECT_ID}::reserve::MarketCoin<${coinType}>`;
   }
 }

--- a/src/queries/market.ts
+++ b/src/queries/market.ts
@@ -107,7 +107,6 @@ export const queryMarket = async (
     const symbol = coin.toUpperCase() as Uppercase<SupportAssetCoins>;
     const marketCoinType = scallopUtils.parseMarketCoinType(
       scallopAddress.get(`core.coins.${coin}.id`),
-      scallopAddress.get('core.packages.protocol.id'),
       coin
     );
     const wrappedType =

--- a/src/queries/obligation.ts
+++ b/src/queries/obligation.ts
@@ -1,6 +1,7 @@
 import { SuiKit, SuiTxBlock } from '@scallop-io/sui-kit';
-import { ScallopAddress } from '../models';
-import { ObligationInterface } from '../types';
+import { PROTOCOL_OBJECT_ID } from '../constants/common';
+import type { ScallopAddress } from '../models';
+import type { ObligationInterface } from '../types';
 
 export const queryObligation = async (
   obligationId: string,
@@ -15,18 +16,12 @@ export const queryObligation = async (
   return queryResult.events[0].parsedJson as ObligationInterface;
 };
 
-export const getObligations = async (
-  ownerAddress: string,
-  scallopAddress: ScallopAddress,
-  suiKit: SuiKit
-) => {
+export const getObligations = async (ownerAddress: string, suiKit: SuiKit) => {
   const owner = ownerAddress || suiKit.currentAddress();
   const keyObjectRefs = await suiKit.provider().getOwnedObjects({
     owner,
     filter: {
-      StructType: `${scallopAddress.get(
-        'core.packages.protocol.id'
-      )}::obligation::ObligationKey`,
+      StructType: `${PROTOCOL_OBJECT_ID}::obligation::ObligationKey`,
     },
   });
   const keyIds = keyObjectRefs.data

--- a/src/txBuilders/coin.ts
+++ b/src/txBuilders/coin.ts
@@ -26,12 +26,7 @@ export const selectMarketCoin = async (
   sender: string
 ) => {
   const coinPackageId = scallopAddress.get(`core.coins.${coinName}.id`);
-  const protocolPackageId = scallopAddress.get('core.packages.protocol.id');
-  const coinType = scallopUtils.parseMarketCoinType(
-    coinPackageId,
-    protocolPackageId,
-    coinName
-  );
+  const coinType = scallopUtils.parseMarketCoinType(coinPackageId, coinName);
   const coins = await scallopUtils.selectCoins(sender, amount, coinType);
   const [takeCoin, leftCoin] = txBlock.takeAmountFromCoins(coins, amount);
   return { takeCoin, leftCoin };

--- a/src/txBuilders/quickMethods.ts
+++ b/src/txBuilders/quickMethods.ts
@@ -25,18 +25,17 @@ const requireSender = (txBlock: SuiTxBlock) => {
 const requireObligationInfo = async (
   ...args: [
     txBlock: SuiTxBlock,
-    scallopAddress: ScallopAddress,
     suiKit: SuiKit,
     obligationId?: SuiTxArg | undefined,
     obligationKey?: SuiTxArg | undefined,
   ]
 ) => {
-  const [txBlock, scallopAddress, suiKit, obligationId, obligationKey] = args;
-  if (args.length === 4 && obligationId) return { obligationId };
-  if (args.length === 5 && obligationId && obligationKey)
+  const [txBlock, suiKit, obligationId, obligationKey] = args;
+  if (args.length === 3 && obligationId) return { obligationId };
+  if (args.length === 4 && obligationId && obligationKey)
     return { obligationId, obligationKey };
   const sender = requireSender(txBlock);
-  const obligations = await getObligations(sender, scallopAddress, suiKit);
+  const obligations = await getObligations(sender, suiKit);
   if (obligations.length === 0) {
     throw new Error(`No obligation found for sender ${sender}`);
   }
@@ -53,7 +52,6 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
       const sender = requireSender(txBlock);
       const { obligationId: obligationArg } = await requireObligationInfo(
         txBlock,
-        scallopAddress,
         suiKit,
         obligationId
       );
@@ -80,7 +78,6 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
       const { obligationId: obligationArg, obligationKey: obligationKeyArg } =
         await requireObligationInfo(
           txBlock,
-          scallopAddress,
           suiKit,
           obligationId,
           obligationKey
@@ -142,7 +139,6 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
       const { obligationId: obligationArg, obligationKey: obligationKeyArg } =
         await requireObligationInfo(
           txBlock,
-          scallopAddress,
           suiKit,
           obligationId,
           obligationKey
@@ -170,7 +166,6 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
       const sender = requireSender(txBlock);
       const { obligationId: obligationArg } = await requireObligationInfo(
         txBlock,
-        scallopAddress,
         suiKit,
         obligationId
       );


### PR DESCRIPTION
- Update the parameter of parseMarketCoinType in scallopUtils, it no longer needs to accept the protocol ID.
- Scallop object type should stay the same after the program is updated.