### PR TITLE
Filter pools and collaterals not yet supported by the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.44.2](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.44.1...v0.44.2) (2023-11-07)
+
+### Features
+
+- add new vsui pool ([63ffffb](https://github.com/scallop-io/sui-scallop-sdk/commit/63ffffb887b022c1a3d3687e7893a2ace38fe4b4))
+
 ### [0.44.1](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.44.0...v0.44.1) (2023-10-25)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/queries/coreQuery.ts
+++ b/src/queries/coreQuery.ts
@@ -59,6 +59,17 @@ export const queryMarket = async (query: ScallopQuery) => {
   const collaterals: MarketCollaterals = {};
 
   for (const pool of marketData.pools) {
+    const coinType = '0x' + pool.type.name;
+    const poolCoinName =
+      query.utils.parseCoinNameFromType<SupportPoolCoins>(coinType);
+    const coinPrice =
+      (await query.utils.getCoinPrices([poolCoinName]))?.[poolCoinName] ?? 0;
+
+    // Filter pools not yet supported by the SDK.
+    if (!SUPPORT_POOLS.includes(poolCoinName)) {
+      continue;
+    }
+
     const parsedMarketPoolData = parseOriginMarketPoolData({
       type: pool.type,
       maxBorrowRate: pool.maxBorrowRate,
@@ -85,12 +96,6 @@ export const queryMarket = async (query: ScallopQuery) => {
       parsedMarketPoolData
     );
 
-    const coinType = '0x' + pool.type.name;
-    const poolCoinName =
-      query.utils.parseCoinNameFromType<SupportPoolCoins>(coinType);
-    const coinPrice =
-      (await query.utils.getCoinPrices([poolCoinName]))?.[poolCoinName] ?? 0;
-
     pools[poolCoinName] = {
       coinName: poolCoinName,
       symbol: query.utils.parseSymbol(poolCoinName),
@@ -110,6 +115,19 @@ export const queryMarket = async (query: ScallopQuery) => {
   }
 
   for (const collateral of marketData.collaterals) {
+    const coinType = '0x' + collateral.type.name;
+    const collateralCoinName =
+      query.utils.parseCoinNameFromType<SupportCollateralCoins>(coinType);
+    const coinPrice =
+      (await query.utils.getCoinPrices([collateralCoinName]))?.[
+        collateralCoinName
+      ] ?? 0;
+
+    // Filter collaterals not yet supported by the SDK.
+    if (!SUPPORT_COLLATERALS.includes(collateralCoinName)) {
+      continue;
+    }
+
     const parsedMarketCollateralData = parseOriginMarketCollateralData({
       type: collateral.type,
       collateralFactor: collateral.collateralFactor,
@@ -125,14 +143,6 @@ export const queryMarket = async (query: ScallopQuery) => {
       query.utils,
       parsedMarketCollateralData
     );
-
-    const coinType = '0x' + collateral.type.name;
-    const collateralCoinName =
-      query.utils.parseCoinNameFromType<SupportCollateralCoins>(coinType);
-    const coinPrice =
-      (await query.utils.getCoinPrices([collateralCoinName]))?.[
-        collateralCoinName
-      ] ?? 0;
 
     collaterals[collateralCoinName] = {
       coinName: collateralCoinName,


### PR DESCRIPTION
## Description
In queryMarket, once the contract is updated, pools and collaterals that are not supported by the latest sdk will be returned, and a known error will occur. In order to solve this problem, we directly filter out these newly added pools to avoid directly causing errors.