### PR TITLE
Fix `getLending` and enhance `getObligation` in portfolio query

### DIFF
--- a/src/queries/borrowIncentiveQuery.ts
+++ b/src/queries/borrowIncentiveQuery.ts
@@ -1,3 +1,4 @@
+import { normalizeStructTag } from '@mysten/sui.js/utils';
 import { SuiTxBlock as SuiKitTxBlock } from '@scallop-io/sui-kit';
 import { SUPPORT_BORROW_INCENTIVE_POOLS } from '../constants';
 import {
@@ -49,7 +50,7 @@ export const queryBorrowIncentivePools = async (
 
   const borrowIncentivePools: BorrowIncentivePools = {};
   for (const pool of borrowIncentivePoolsQueryData.incentive_pools) {
-    const coinType = '0x' + pool.pool_type.name;
+    const coinType = normalizeStructTag(pool.pool_type.name);
     const coinName =
       query.utils.parseCoinNameFromType<SupportBorrowIncentiveCoins>(coinType);
     const rewardCoinName =

--- a/src/queries/coreQuery.ts
+++ b/src/queries/coreQuery.ts
@@ -1,3 +1,4 @@
+import { normalizeStructTag } from '@mysten/sui.js/utils';
 import { SuiTxBlock as SuiKitTxBlock } from '@scallop-io/sui-kit';
 import BigNumber from 'bignumber.js';
 import {
@@ -59,7 +60,7 @@ export const queryMarket = async (query: ScallopQuery) => {
   const collaterals: MarketCollaterals = {};
 
   for (const pool of marketData.pools) {
-    const coinType = '0x' + pool.type.name;
+    const coinType = normalizeStructTag(pool.type.name);
     const poolCoinName =
       query.utils.parseCoinNameFromType<SupportPoolCoins>(coinType);
     const coinPrice =
@@ -115,7 +116,7 @@ export const queryMarket = async (query: ScallopQuery) => {
   }
 
   for (const collateral of marketData.collaterals) {
-    const coinType = '0x' + collateral.type.name;
+    const coinType = normalizeStructTag(collateral.type.name);
     const collateralCoinName =
       query.utils.parseCoinNameFromType<SupportCollateralCoins>(coinType);
     const coinPrice =

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -164,7 +164,9 @@ export const getLending = async (
       availableUnstakeAmount = availableUnstakeAmount.plus(
         accountStakedMarketCoinAmount
       );
-      availableUnstakeCoin = availableUnstakeAmount.shiftedBy(-1 * coinDecimal);
+      availableUnstakeCoin = availableUnstakeAmount.shiftedBy(
+        -1 * spool.coinDecimal
+      );
 
       const baseIndexRate = 1_000_000_000;
       const increasedPointRate = spool?.currentPointIndex
@@ -173,13 +175,15 @@ export const getLending = async (
           )
         : 1;
       availableClaimAmount = availableClaimAmount.plus(
-        BigNumber(stakeAccount.staked)
+        accountStakedMarketCoinAmount
           .multipliedBy(increasedPointRate)
           .plus(stakeAccount.points)
           .multipliedBy(spool.exchangeRateNumerator)
           .dividedBy(spool.exchangeRateDenominator)
       );
-      availableClaimCoin = availableClaimAmount.shiftedBy(-1 * coinDecimal);
+      availableClaimCoin = availableClaimAmount.shiftedBy(
+        -1 * spool.rewardCoinDecimal
+      );
     }
   }
 

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -19,6 +19,7 @@ import type {
   CoinPrices,
   SupportMarketCoins,
   TotalValueLocked,
+  SupportBorrowIncentiveCoins,
 } from '../types';
 
 /**
@@ -302,12 +303,16 @@ export const getObligationAccount = async (
     ]),
   ];
   const obligationQuery = await query.queryObligation(obligationId);
+  const borrowIncentivePools = await query.getBorrowIncentivePools();
+  const borrowIncentiveAccounts =
+    await query.getBorrowIncentiveAccounts(obligationId);
   coinPrices = coinPrices || (await query.utils.getCoinPrices(assetCoinNames));
   coinAmounts =
     coinAmounts || (await query.getCoinAmounts(assetCoinNames, ownerAddress));
 
   const collaterals: ObligationAccount['collaterals'] = {};
   const debts: ObligationAccount['debts'] = {};
+  const borrowIncentives: ObligationAccount['borrowIncentives'] = {};
   let totalDepositedPools = 0;
   let totalDepositedValue = BigNumber(0);
   let totalBorrowCapacityValue = BigNumber(0);
@@ -423,6 +428,50 @@ export const getObligationAccount = async (
     }
   }
 
+  for (const [poolCoinName, borrowIncentiveAccount] of Object.entries(
+    borrowIncentiveAccounts
+  )) {
+    const coinName = poolCoinName as SupportBorrowIncentiveCoins;
+    const borrowIncentivePool = borrowIncentivePools[coinName];
+
+    let availableClaimAmount = BigNumber(0);
+    let availableClaimCoin = BigNumber(0);
+    if (borrowIncentivePool) {
+      const accountBorrowedAmount = BigNumber(borrowIncentiveAccount.amount);
+      const baseIndexRate = 1_000_000_000;
+      const increasedPointRate = borrowIncentivePool.currentPointIndex
+        ? BigNumber(
+            borrowIncentivePool.currentPointIndex - borrowIncentiveAccount.index
+          ).dividedBy(baseIndexRate)
+        : 1;
+      availableClaimAmount = availableClaimAmount.plus(
+        accountBorrowedAmount
+          .multipliedBy(increasedPointRate)
+          .plus(borrowIncentiveAccount.points)
+          .multipliedBy(borrowIncentivePool.exchangeRateNumerator)
+          .dividedBy(borrowIncentivePool.exchangeRateDenominator)
+      );
+      availableClaimCoin = availableClaimAmount.shiftedBy(
+        -1 * borrowIncentivePool.rewardCoinDecimal
+      );
+
+      if (availableClaimAmount.isGreaterThan(0)) {
+        borrowIncentives[coinName] = {
+          coinName: borrowIncentivePool.coinName,
+          coinType: borrowIncentivePool.coinType,
+          rewardCoinType: borrowIncentivePool.rewardCoinType,
+          symbol: borrowIncentivePool.symbol,
+          coinDecimal: borrowIncentivePool.coinDecimal,
+          rewardCoinDecimal: borrowIncentivePool.rewardCoinDecimal,
+          coinPrice: borrowIncentivePool.coinPrice,
+          rewardCoinPrice: borrowIncentivePool.rewardCoinPrice,
+          availableClaimAmount: availableClaimAmount.toNumber(),
+          availableClaimCoin: availableClaimCoin.toNumber(),
+        };
+      }
+    }
+  }
+
   let riskLevel =
     totalRequiredCollateralValue.isZero() &&
     totalBorrowedValueWithWeight.isZero()
@@ -476,6 +525,7 @@ export const getObligationAccount = async (
     totalBorrowedPools,
     collaterals,
     debts,
+    borrowIncentives,
   };
 
   for (const [collateralCoinName, obligationCollateral] of Object.entries(
@@ -504,10 +554,10 @@ export const getObligationAccount = async (
         .toNumber();
     }
   }
-  for (const [assetCoinName, obligationDebt] of Object.entries(
+  for (const [poolCoinName, obligationDebt] of Object.entries(
     obligationAccount.debts
   )) {
-    const marketPool = market.pools[assetCoinName as SupportPoolCoins];
+    const marketPool = market.pools[poolCoinName as SupportPoolCoins];
     if (marketPool) {
       const availableRepayAmount = BigNumber(
         obligationDebt.availableRepayAmount

--- a/src/queries/spoolQuery.ts
+++ b/src/queries/spoolQuery.ts
@@ -247,9 +247,9 @@ export const getStakeAccounts = async (
       if (normalizeStructTag(type) === stakeMarketCoinTypes.ssui) {
         stakeAccounts.ssui.push({
           id,
-          type,
+          type: normalizeStructTag(type),
           stakePoolId,
-          stakeType,
+          stakeType: normalizeStructTag(stakeType),
           staked,
           index,
           points,
@@ -258,9 +258,9 @@ export const getStakeAccounts = async (
       } else if (normalizeStructTag(type) === stakeMarketCoinTypes.susdc) {
         stakeAccounts.susdc.push({
           id,
-          type,
+          type: normalizeStructTag(type),
           stakePoolId,
-          stakeType,
+          stakeType: normalizeStructTag(stakeType),
           staked,
           index,
           points,
@@ -269,9 +269,9 @@ export const getStakeAccounts = async (
       } else if (normalizeStructTag(type) === stakeMarketCoinTypes.susdt) {
         stakeAccounts.susdt.push({
           id,
-          type,
+          type: normalizeStructTag(type),
           stakePoolId,
-          stakeType,
+          stakeType: normalizeStructTag(stakeType),
           staked,
           index,
           points,
@@ -325,13 +325,13 @@ export const getStakePool = async (
       const lastUpdate = Number(fields.last_update);
       stakePool = {
         id,
-        type,
+        type: normalizeStructTag(type),
         maxPoint,
         distributedPoint,
         pointPerPeriod,
         period,
         maxStake,
-        stakeType,
+        stakeType: normalizeStructTag(stakeType),
         totalStaked,
         index,
         createdAt,
@@ -384,7 +384,7 @@ export const getStakeRewardPool = async (
       const claimedRewards = Number(fields.claimed_rewards);
       stakeRewardPool = {
         id,
-        type,
+        type: normalizeStructTag(type),
         stakePoolId,
         ratioNumerator,
         ratioDenominator,

--- a/src/types/query/portfolio.ts
+++ b/src/types/query/portfolio.ts
@@ -66,6 +66,9 @@ export type ObligationAccount = {
     Record<SupportCollateralCoins, ObligationCollateral>
   >;
   debts: OptionalKeys<Record<SupportPoolCoins, ObligationDebt>>;
+  borrowIncentives: OptionalKeys<
+    Record<SupportPoolCoins, ObligationBorrowIncentive>
+  >;
 };
 
 export type ObligationCollateral = {
@@ -100,6 +103,19 @@ export type ObligationDebt = {
   availableBorrowCoin: number;
   availableRepayAmount: number;
   availableRepayCoin: number;
+};
+
+export type ObligationBorrowIncentive = {
+  coinName: SupportPoolCoins;
+  coinType: string;
+  rewardCoinType: string;
+  symbol: string;
+  coinDecimal: number;
+  rewardCoinDecimal: number;
+  coinPrice: number;
+  rewardCoinPrice: number;
+  availableClaimAmount: number;
+  availableClaimCoin: number;
 };
 
 export type TotalValueLocked = {

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -36,7 +36,7 @@ export const parseOriginMarketPoolData = (
   originMarketPoolData: OriginMarketPoolData
 ): ParsedMarketPoolData => {
   return {
-    coinType: '0x' + originMarketPoolData.type.name,
+    coinType: normalizeStructTag(originMarketPoolData.type.name),
     // Parse origin data required for basic calculations.
     maxBorrowRate: Number(originMarketPoolData.maxBorrowRate.value) / 2 ** 32,
     borrowRate: Number(originMarketPoolData.interestRate.value) / 2 ** 32,
@@ -171,7 +171,7 @@ export const parseOriginMarketCollateralData = (
   originMarketCollateralData: OriginMarketCollateralData
 ): ParsedMarketCollateralData => {
   return {
-    coinType: '0x' + originMarketCollateralData.type.name,
+    coinType: normalizeStructTag(originMarketCollateralData.type.name),
     collateralFactor:
       Number(originMarketCollateralData.collateralFactor.value) / 2 ** 32,
     liquidationFactor:
@@ -225,7 +225,7 @@ export const parseOriginSpoolData = (
   originSpoolData: OriginSpoolData
 ): ParsedSpoolData => {
   return {
-    stakeType: '0x' + originSpoolData.stakeType.fields.name,
+    stakeType: normalizeStructTag(originSpoolData.stakeType.fields.name),
     maxPoint: Number(originSpoolData.maxDistributedPoint),
     distributedPoint: Number(originSpoolData.distributedPoint),
     pointPerPeriod: Number(originSpoolData.distributedPointPerPeriod),


### PR DESCRIPTION
## Description
- refactor: use `normalizeStructTag` to handle coin type in query functions.
- fix: wrong availableClaim in getLending.
- feat: add avaliable claim of borrow incentives in getObligationAccount.