### PR TITLE
feat: add an object id address to dynamically update protocol object

### DIFF
--- a/src/models/scallopAddress.ts
+++ b/src/models/scallopAddress.ts
@@ -120,6 +120,7 @@ export class ScallopAddress {
         core: {
           version: '',
           versionCap: '',
+          object: '',
           market: '',
           adminCap: '',
           coinDecimalsRegistry: '',

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -82,7 +82,7 @@ export class ScallopClient {
    */
   async getObligations(ownerAddress?: string) {
     const owner = ownerAddress || this.walletAddress;
-    return getObligations(owner, this.suiKit);
+    return getObligations(owner, this.suiKit, this.address);
   }
 
   /**

--- a/src/models/scallopUtils.ts
+++ b/src/models/scallopUtils.ts
@@ -129,11 +129,15 @@ export class ScallopUtils {
    *
    * @return marketCoinType.
    */
-  public parseMarketCoinType(coinPackageId: string, coinName: string) {
+  public parseMarketCoinType(
+    protocolObjectId: string = PROTOCOL_OBJECT_ID,
+    coinPackageId: string,
+    coinName: string
+  ) {
     const coinType = this.parseCoinType(
       coinName === 'sui' ? SUI_FRAMEWORK_ADDRESS : coinPackageId,
       coinName
     );
-    return `${PROTOCOL_OBJECT_ID}::reserve::MarketCoin<${coinType}>`;
+    return `${protocolObjectId}::reserve::MarketCoin<${coinType}>`;
   }
 }

--- a/src/queries/market.ts
+++ b/src/queries/market.ts
@@ -107,6 +107,7 @@ export const queryMarket = async (
     ) as SupportAssetCoins;
     const symbol = coin.toUpperCase() as Uppercase<SupportAssetCoins>;
     const marketCoinType = scallopUtils.parseMarketCoinType(
+      scallopAddress.get(`core.object`),
       scallopAddress.get(`core.coins.${coin}.id`),
       coin
     );

--- a/src/queries/obligation.ts
+++ b/src/queries/obligation.ts
@@ -16,12 +16,18 @@ export const queryObligation = async (
   return queryResult.events[0].parsedJson as ObligationInterface;
 };
 
-export const getObligations = async (ownerAddress: string, suiKit: SuiKit) => {
+export const getObligations = async (
+  ownerAddress: string,
+  suiKit: SuiKit,
+  scallopAddress: ScallopAddress
+) => {
   const owner = ownerAddress || suiKit.currentAddress();
+  const protocolObjectId =
+    scallopAddress.get('core.object') || PROTOCOL_OBJECT_ID;
   const keyObjectRefs = await suiKit.provider().getOwnedObjects({
     owner,
     filter: {
-      StructType: `${PROTOCOL_OBJECT_ID}::obligation::ObligationKey`,
+      StructType: `${protocolObjectId}::obligation::ObligationKey`,
     },
   });
   const keyIds = keyObjectRefs.data

--- a/src/txBuilders/coin.ts
+++ b/src/txBuilders/coin.ts
@@ -26,7 +26,12 @@ export const selectMarketCoin = async (
   sender: string
 ) => {
   const coinPackageId = scallopAddress.get(`core.coins.${coinName}.id`);
-  const coinType = scallopUtils.parseMarketCoinType(coinPackageId, coinName);
+  const protocolObjectId = scallopAddress.get(`core.object`);
+  const coinType = scallopUtils.parseMarketCoinType(
+    protocolObjectId,
+    coinPackageId,
+    coinName
+  );
   const coins = await scallopUtils.selectCoins(sender, amount, coinType);
   const [takeCoin, leftCoin] = txBlock.takeAmountFromCoins(coins, amount);
   return { takeCoin, leftCoin };

--- a/src/txBuilders/quickMethods.ts
+++ b/src/txBuilders/quickMethods.ts
@@ -26,16 +26,17 @@ const requireObligationInfo = async (
   ...args: [
     txBlock: SuiTxBlock,
     suiKit: SuiKit,
+    scallopAddress: ScallopAddress,
     obligationId?: SuiTxArg | undefined,
     obligationKey?: SuiTxArg | undefined,
   ]
 ) => {
-  const [txBlock, suiKit, obligationId, obligationKey] = args;
+  const [txBlock, suiKit, scallopAddress, obligationId, obligationKey] = args;
   if (args.length === 3 && obligationId) return { obligationId };
   if (args.length === 4 && obligationId && obligationKey)
     return { obligationId, obligationKey };
   const sender = requireSender(txBlock);
-  const obligations = await getObligations(sender, suiKit);
+  const obligations = await getObligations(sender, suiKit, scallopAddress);
   if (obligations.length === 0) {
     throw new Error(`No obligation found for sender ${sender}`);
   }
@@ -53,6 +54,7 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
       const { obligationId: obligationArg } = await requireObligationInfo(
         txBlock,
         suiKit,
+        scallopAddress,
         obligationId
       );
 
@@ -79,6 +81,7 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
         await requireObligationInfo(
           txBlock,
           suiKit,
+          scallopAddress,
           obligationId,
           obligationKey
         );
@@ -140,6 +143,7 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
         await requireObligationInfo(
           txBlock,
           suiKit,
+          scallopAddress,
           obligationId,
           obligationKey
         );
@@ -167,6 +171,7 @@ const scallopQuickMethodsHandler: ScallopQuickMethodsHandler = {
       const { obligationId: obligationArg } = await requireObligationInfo(
         txBlock,
         suiKit,
+        scallopAddress,
         obligationId
       );
 

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -197,6 +197,7 @@ export interface AddressesInterface {
   core: {
     version: string;
     versionCap: string;
+    object: string;
     market: string;
     adminCap: string;
     coinDecimalsRegistry: string;


### PR DESCRIPTION
## Description
To solve the problem caused by the inability to dynamically update protocol objects in specific usage scenarios. When using a new protocol contract addresses, its maket coin and obligation object id need to be adjusted accordingly.