### PR TITLE
Include all collateral and debt info by default in `GetObligationAccount` query

### DIFF
--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -444,10 +444,14 @@ export class ScallopQuery {
    * borrowing and obligation information for specific pool.
    *
    * @param obligationId - The obligation id.
+   * @param ownerAddress - The owner address.
    * @return Borrowing and collateral information.
    */
-  public async getObligationAccount(obligationId: string) {
-    return await getObligationAccount(this, obligationId);
+  public async getObligationAccount(
+    obligationId: string,
+    ownerAddress?: string
+  ) {
+    return await getObligationAccount(this, obligationId, ownerAddress);
   }
 
   /**

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -267,6 +267,7 @@ describe('Test Portfolio Query', async () => {
     networkType: NETWORK,
   });
   const scallopQuery = await scallopSDK.createScallopQuery();
+  console.info('Your wallet:', scallopQuery.suiKit.currentAddress());
 
   it('Should get user lendings data', async () => {
     const lendings = await scallopQuery.getLendings(['sui', 'usdc']);
@@ -304,7 +305,8 @@ describe('Test Portfolio Query', async () => {
     expect(obligations.length).toBeGreaterThan(0);
 
     const obligationAccount = await scallopQuery.getObligationAccount(
-      obligations[0].id
+      obligations[0].id,
+      scallopQuery.suiKit.currentAddress()
     );
     if (ENABLE_LOG) {
       console.info('Obligation account:');


### PR DESCRIPTION
## Description
Originally, only the collateral and debt records generated after deposit or borrow would be included in the `obligationAccount`. Now the default includes all collateral and debet related information.