### PR TITLE
Enhance client and optimize query

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -40,7 +40,7 @@ export const SUPPORT_SPOOLS = ['ssui', 'susdc', 'susdt'] as const;
 
 export const SUPPORT_SPOOLS_REWARDS = ['sui'] as const;
 
-export const SUPPORT_BORROW_INCENTIVE_POOLS = ['sui', 'usdc'] as const;
+export const SUPPORT_BORROW_INCENTIVE_POOLS = ['sui', 'usdc', 'usdt'] as const;
 
 export const SUPPORT_BORROW_INCENTIVE_REWARDS = ['sui'] as const;
 export const SUPPORT_ORACLES = ['supra', 'switchboard', 'pyth'] as const;

--- a/src/constants/enum.ts
+++ b/src/constants/enum.ts
@@ -78,6 +78,7 @@ export const spoolRewardCoins: StakeRewardCoins = {
 export const borrowIncentiveRewardCoins: BorrowIncentiveRewardCoins = {
   sui: 'sui',
   usdc: 'sui',
+  usdt: 'sui',
 };
 
 export const coinIds: AssetCoinIds = {

--- a/src/types/query/portfolio.ts
+++ b/src/types/query/portfolio.ts
@@ -99,6 +99,8 @@ export type ObligationDebt = {
   borrowedValue: number;
   borrowedValueWithWeight: number;
   borrowIndex: number;
+  requiredRepayAmount: number;
+  requiredRepayCoin: number;
   availableBorrowAmount: number;
   availableBorrowCoin: number;
   availableRepayAmount: number;

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -612,3 +612,29 @@ export const maxBigNumber = (...args: BigNumber.Value[]) => {
     )
   );
 };
+
+/**
+ * Dynamically adjust the decrease or increase ratio according to the amout
+ * @param amount - The amount required to calculate factor.
+ * @param scaleStep - The scale step required to determine the factor..
+ * @param type - The type of the calculation.
+ * @return The estimated factor
+ * */
+export const estimatedFactor = (
+  amount: number,
+  scaleStep: number,
+  type: 'increase' | 'decrease'
+) => {
+  const amountOfDigits = Math.max(
+    1,
+    Math.floor(Math.log10(Math.abs(amount)) + 1)
+  );
+
+  const adjustScale =
+    Math.max(Math.floor((amountOfDigits - 1) / scaleStep), 1) + 1;
+
+  let adjustFactor = Math.pow(10, -adjustScale);
+  adjustFactor = type === 'increase' ? 1 - adjustFactor : 1 + adjustFactor;
+
+  return adjustFactor;
+};

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -277,7 +277,8 @@ describe('Test Scallop Client - Core Method', async () => {
       'sui',
       0.4 * 10 ** 8,
       true,
-      obligations[0].id
+      obligations[0].id,
+      obligations[0].keyId
     );
     if (ENABLE_LOG) {
       console.info('RepayResult:', repayResult);


### PR DESCRIPTION
## Description
- Add `usdt` borrow incentive support.
- `Borrow` and `repay` with sign tx in client support borrow incentive.
- Add `requiredRepay` field and change the value of `availableRepay` in `obligationAccount`
  - `requiredRepay`: represents the total number or amount of coins that need to be repaid.
  - `availableRepay`: represents the number or amount of all owned coins that can repay.
- Added estimated factor function to optimize estimation of `collateral withdraw`, `available borrow` and `required repay`.