### PR TITLE
fix: remove coin name for `stakeObligation` and `unstakeObligation`

### DIFF
--- a/src/builders/borrowIncentiveBuilder.ts
+++ b/src/builders/borrowIncentiveBuilder.ts
@@ -81,8 +81,10 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
       obligationAccessStore: builder.address.get('core.obligationAccessStore'),
     };
     return {
-      stakeObligation: (obligationId, obligaionKey, coinName) => {
-        const rewardCoinName = borrowIncentiveRewardCoins[coinName];
+      stakeObligation: (obligationId, obligaionKey) => {
+        // NOTE: Pools without incentives also need to stake after change obligation,
+        // the default here use sui as reward coin.
+        const rewardCoinName = 'sui';
         const rewardType = builder.utils.parseCoinType(rewardCoinName);
         txBlock.moveCall(
           `${borrowIncentiveIds.borrowIncentivePkg}::user::stake`,
@@ -97,8 +99,10 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
           [rewardType]
         );
       },
-      unstakeObligation: (obligationId, obligaionKey, coinName) => {
-        const rewardCoinName = borrowIncentiveRewardCoins[coinName];
+      unstakeObligation: (obligationId, obligaionKey) => {
+        // NOTE: Pools without incentives also need to unstake to change obligation,
+        // the default here use sui as reward coin.
+        const rewardCoinName = 'sui';
         const rewardType = builder.utils.parseCoinType(rewardCoinName);
         txBlock.moveCall(
           `${borrowIncentiveIds.borrowIncentivePkg}::user::unstake`,
@@ -145,7 +149,7 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
 const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
   ({ builder, txBlock }) => {
     return {
-      stakeObligationQuick: async (coinName, obligation, obligationKey) => {
+      stakeObligationQuick: async (obligation, obligationKey) => {
         const {
           obligationId: obligationArg,
           obligationKey: obligationtKeyArg,
@@ -166,10 +170,10 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
           );
 
         if (!obligationLocked || unstakeObligationBeforeStake) {
-          txBlock.stakeObligation(obligationArg, obligationtKeyArg, coinName);
+          txBlock.stakeObligation(obligationArg, obligationtKeyArg);
         }
       },
-      unstakeObligationQuick: async (coinName, obligation, obligationKey) => {
+      unstakeObligationQuick: async (obligation, obligationKey) => {
         const {
           obligationId: obligationArg,
           obligationKey: obligationtKeyArg,
@@ -182,7 +186,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
         );
 
         if (obligationLocked) {
-          txBlock.unstakeObligation(obligationArg, obligationtKeyArg, coinName);
+          txBlock.unstakeObligation(obligationArg, obligationtKeyArg);
         }
       },
       claimBorrowIncentiveQuick: async (

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -485,11 +485,7 @@ export class ScallopClient {
       SUPPORT_BORROW_INCENTIVE_POOLS as readonly SupportPoolCoins[]
     ).includes(poolCoinName);
     if (sign && availableStake) {
-      await txBlock.unstakeObligationQuick(
-        poolCoinName as SupportBorrowIncentiveCoins,
-        obligationId,
-        obligationKey
-      );
+      await txBlock.unstakeObligationQuick(obligationId, obligationKey);
     }
     const coin = await txBlock.borrowQuick(
       amount,
@@ -499,11 +495,7 @@ export class ScallopClient {
     );
     txBlock.transferObjects([coin], sender);
     if (sign && availableStake) {
-      await txBlock.stakeObligationQuick(
-        poolCoinName as SupportBorrowIncentiveCoins,
-        obligationId,
-        obligationKey
-      );
+      await txBlock.stakeObligationQuick(obligationId, obligationKey);
     }
 
     if (sign) {
@@ -541,19 +533,11 @@ export class ScallopClient {
       SUPPORT_BORROW_INCENTIVE_POOLS as readonly SupportPoolCoins[]
     ).includes(poolCoinName);
     if (sign && availableStake) {
-      await txBlock.unstakeObligationQuick(
-        poolCoinName as SupportBorrowIncentiveCoins,
-        obligationId,
-        obligationKey
-      );
+      await txBlock.unstakeObligationQuick(obligationId, obligationKey);
     }
     await txBlock.repayQuick(amount, poolCoinName, obligationId);
     if (sign && availableStake) {
-      await txBlock.stakeObligationQuick(
-        poolCoinName as SupportBorrowIncentiveCoins,
-        obligationId,
-        obligationKey
-      );
+      await txBlock.stakeObligationQuick(obligationId, obligationKey);
     }
 
     if (sign) {
@@ -860,14 +844,13 @@ export class ScallopClient {
   /**
    * stake obligaion.
    *
-   * @param sign - Decide to directly sign the transaction or return the transaction block.
    * @param obligaionId - The obligation account object.
    * @param obligaionKeyId - The obligation key account object.
+   * @param sign - Decide to directly sign the transaction or return the transaction block.
    * @param walletAddress - The wallet address of the owner.
    * @return Transaction block response or transaction block
    */
   public async stakeObligation<S extends boolean>(
-    coinName: SupportBorrowIncentiveCoins,
     obligaionId: string,
     obligaionKeyId: string,
     sign: S = true as S,
@@ -877,7 +860,7 @@ export class ScallopClient {
     const sender = walletAddress || this.walletAddress;
     txBlock.setSender(sender);
 
-    await txBlock.stakeObligationQuick(coinName, obligaionId, obligaionKeyId);
+    await txBlock.stakeObligationQuick(obligaionId, obligaionKeyId);
 
     if (sign) {
       return (await this.suiKit.signAndSendTxn(
@@ -891,14 +874,13 @@ export class ScallopClient {
   /**
    * unstake obligaion.
    *
-   * @param sign - Decide to directly sign the transaction or return the transaction block.
    * @param obligaionId - The obligation account object.
    * @param obligaionKeyId - The obligation key account object.
+   * @param sign - Decide to directly sign the transaction or return the transaction block.
    * @param walletAddress - The wallet address of the owner.
    * @return Transaction block response or transaction block
    */
   public async unstakeObligation<S extends boolean>(
-    coinName: SupportBorrowIncentiveCoins,
     obligaionId: string,
     obligaionKeyId: string,
     sign: S = true as S,
@@ -908,7 +890,7 @@ export class ScallopClient {
     const sender = walletAddress || this.walletAddress;
     txBlock.setSender(sender);
 
-    await txBlock.unstakeObligationQuick(coinName, obligaionId, obligaionKeyId);
+    await txBlock.unstakeObligationQuick(obligaionId, obligaionKeyId);
 
     if (sign) {
       return (await this.suiKit.signAndSendTxn(

--- a/src/types/builder/borrowIncentive.ts
+++ b/src/types/builder/borrowIncentive.ts
@@ -17,13 +17,11 @@ export type BorrowIncentiveIds = {
 export type BorrowIncentiveNormalMethods = {
   stakeObligation: (
     obligation: SuiAddressArg,
-    obligaionKey: SuiAddressArg,
-    coinName: SupportBorrowIncentiveCoins
+    obligaionKey: SuiAddressArg
   ) => void;
   unstakeObligation: (
     obligation: SuiAddressArg,
-    obligaionKey: SuiAddressArg,
-    coinName: SupportBorrowIncentiveCoins
+    obligaionKey: SuiAddressArg
   ) => void;
   claimBorrowIncentive: (
     obligation: SuiAddressArg,
@@ -34,12 +32,10 @@ export type BorrowIncentiveNormalMethods = {
 
 export type BorrowIncentiveQuickMethods = {
   stakeObligationQuick(
-    coinName: SupportBorrowIncentiveCoins,
     obligation?: SuiAddressArg,
     obligationKey?: SuiAddressArg
   ): Promise<void>;
   unstakeObligationQuick(
-    coinName: SupportBorrowIncentiveCoins,
     obligation?: SuiAddressArg,
     obligationKey?: SuiAddressArg
   ): Promise<void>;

--- a/test/builder.spec.ts
+++ b/test/builder.spec.ts
@@ -236,7 +236,7 @@ describe('Test Scallop Borrow Incentive Builder', async () => {
     const tx = scallopBuilder.createTxBlock();
     // Sender is required to invoke "stakeObligationQuick".
     tx.setSender(sender);
-    await tx.stakeObligationQuick('sui');
+    await tx.stakeObligationQuick();
     const stakeObligationQuickResult =
       await scallopBuilder.signAndSendTxBlock(tx);
     if (ENABLE_LOG) {
@@ -251,7 +251,7 @@ describe('Test Scallop Borrow Incentive Builder', async () => {
     const tx = scallopBuilder.createTxBlock();
     // Sender is required to invoke "unstakeObligationQuick".
     tx.setSender(sender);
-    await tx.unstakeObligationQuick('sui');
+    await tx.unstakeObligationQuick();
     const unstakeObligationQuickResult =
       await scallopBuilder.signAndSendTxBlock(tx);
     if (ENABLE_LOG) {


### PR DESCRIPTION
## Description
All obligation needs to be unlocked in order to change it, so no matter which pool has a borrow incentive reward or not, the movecall needs to be called normally with these functions which been changes in this commit, so we remove the parameters `coinName` required by the functions.