### PR TITLE
feat: lending query adds `conversionRate` and `marketCoinPrice` fields

### DIFF
--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -200,6 +200,9 @@ export const getLending = async (
   const suppliedCoin = suppliedAmount.shiftedBy(-1 * coinDecimal);
   const suppliedValue = suppliedCoin.multipliedBy(coinPrice ?? 0);
 
+  const marketCoinPrice = BigNumber(coinPrice ?? 0).multipliedBy(
+    marketPool?.conversionRate ?? 1
+  );
   const unstakedMarketAmount = BigNumber(marketCoinAmount);
   const unstakedMarketCoin = unstakedMarketAmount.shiftedBy(-1 * coinDecimal);
 
@@ -221,6 +224,8 @@ export const getLending = async (
     marketCoinType: query.utils.parseMarketCoinType(poolCoinName),
     coinDecimal: coinDecimal,
     coinPrice: coinPrice ?? 0,
+    conversionRate: marketPool?.conversionRate ?? 1,
+    marketCoinPrice: marketCoinPrice.toNumber(),
     supplyApr: marketPool?.supplyApr ?? 0,
     supplyApy: marketPool?.supplyApy ?? 0,
     rewardApr: spool?.rewardApr ?? 0,

--- a/src/types/query/portfolio.ts
+++ b/src/types/query/portfolio.ts
@@ -1,4 +1,5 @@
 import type { MarketPool } from './core';
+import type { Spool } from './spool';
 import type { SupportPoolCoins, SupportCollateralCoins } from '../constant';
 
 type OptionalKeys<T> = {
@@ -19,7 +20,9 @@ export type Lending = Required<
     | 'marketCoinType'
     | 'coinDecimal'
     | 'coinPrice'
-  >
+    | 'conversionRate'
+  > &
+    Pick<Spool, 'marketCoinPrice'>
 > & {
   supplyApr: number;
   supplyApy: number;


### PR DESCRIPTION
## Description
Add commonly used data to the return of `getLending` query.