### PR TITLE
docs: modify wrong function name

### DIFF
--- a/document/client.md
+++ b/document/client.md
@@ -22,7 +22,7 @@ The query methods in the client have been migrated to the query instance. These 
   // Get stake pool data.
   const stakePoolData = await client.getStakePool('ssui');
   // Get reward pool data.
-  const rewardPoolData = await client.getRewardPool('ssui');
+  const rewardPoolData = await client.getStakeRewardPool('ssui');
   ```
 
 ## Core Interaction Method

--- a/document/query.md
+++ b/document/query.md
@@ -102,10 +102,10 @@
   const suiStakePool = await scallopQuery.getStakePool('ssui');
 
   // Get multiple reward pools data.
-  const rewardPools = await scallopQuery.getRewardPools(['ssui', 'susdc']);
+  const rewardPools = await scallopQuery.getStakeRewardPools(['ssui', 'susdc']);
 
   // Get reward pool data separately.
-  const rewardPool = await scallopQuery.getRewardPool('ssui');
+  const rewardPool = await scallopQuery.getStakeRewardPool('ssui');
 
   // For the return type, please refer to the type definition of the source code, which is located in the project `src/types/query` folder location.
   ```


### PR DESCRIPTION
## Description
Correct `getRewardPool` and `getRewardPools` as `getStakeRewardPool` and `getStakeRewardPools` in sample code.