### PR TITLE
feat: add multiple pyth endpoints

### DIFF
--- a/src/builders/oracle.ts
+++ b/src/builders/oracle.ts
@@ -37,7 +37,9 @@ export const updateOracles = async (
     );
 
     // iterate through the endpoints
-    const endpoints = PYTH_ENDPOINTS[builder.isTestnet ? 'testnet' : 'mainnet'];
+    const endpoints =
+      builder.params.pythEndpoints ??
+      PYTH_ENDPOINTS[builder.isTestnet ? 'testnet' : 'mainnet'];
     for (const endpoint of endpoints) {
       try {
         const pythConnection = new SuiPriceServiceConnection(endpoint);
@@ -49,15 +51,13 @@ export const updateOracles = async (
           priceIds
         );
 
-        return;
+        break;
       } catch (e) {
         console.warn(
           `Failed to update price feeds with endpoint ${endpoint}: ${e}`
         );
       }
     }
-
-    throw new Error('Failed to update price feeds with all endpoins');
   }
 
   // Remove duplicate coin names.

--- a/src/builders/oracle.ts
+++ b/src/builders/oracle.ts
@@ -36,7 +36,7 @@ export const updateOracles = async (
       builder.address.get(`core.coins.${assetCoinName}.oracle.pyth.feed`)
     );
 
-    // iterate through the priceIds and update the price feeds
+    // iterate through the endpoints
     const endpoints = PYTH_ENDPOINTS[builder.isTestnet ? 'testnet' : 'mainnet'];
     for (const endpoint of endpoints) {
       try {

--- a/src/constants/pyth.ts
+++ b/src/constants/pyth.ts
@@ -1,0 +1,6 @@
+export const PYTH_ENDPOINTS: {
+  [k in 'mainnet' | 'testnet']: Readonly<string[]>;
+} = {
+  testnet: ['https://hermes-beta.pyth.network'],
+  mainnet: ['https://hermes.pyth.network', 'https://scallop.rpc.p2p.world'],
+} as const;

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -84,15 +84,15 @@ export class ScallopClient {
   /**
    * Request the scallop API to initialize data.
    *
-   * @param forece - Whether to force initialization.
+   * @param force - Whether to force initialization.
    */
-  public async init(forece: boolean = false) {
-    if (forece || !this.address.getAddresses()) {
+  public async init(force: boolean = false) {
+    if (force || !this.address.getAddresses()) {
       await this.address.read();
     }
-    await this.query.init(forece);
-    await this.utils.init(forece);
-    await this.builder.init(forece);
+    await this.query.init(force);
+    await this.utils.init(force);
+    await this.builder.init(force);
   }
 
   /* ==================== Query Method ==================== */

--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -87,13 +87,13 @@ export class ScallopQuery {
   /**
    * Request the scallop API to initialize data.
    *
-   * @param forece - Whether to force initialization.
+   * @param force - Whether to force initialization.
    */
-  public async init(forece: boolean = false) {
-    if (forece || !this.address.getAddresses()) {
+  public async init(force: boolean = false) {
+    if (force || !this.address.getAddresses()) {
       await this.address.read();
     }
-    await this.utils.init(forece);
+    await this.utils.init(force);
   }
 
   /* ==================== Core Query Methods ==================== */

--- a/src/models/scallopUtils.ts
+++ b/src/models/scallopUtils.ts
@@ -392,7 +392,9 @@ export class ScallopUtils {
     }
 
     if (lackPricesCoinNames.length > 0) {
-      const endpoints = PYTH_ENDPOINTS[this.isTestnet ? 'testnet' : 'mainnet'];
+      const endpoints =
+        this.params.pythEndpoints ??
+        PYTH_ENDPOINTS[this.isTestnet ? 'testnet' : 'mainnet'];
       try {
         for (const endpoint of endpoints) {
           try {

--- a/src/models/scallopUtils.ts
+++ b/src/models/scallopUtils.ts
@@ -33,6 +33,7 @@ import type {
   PriceMap,
   CoinWrappedType,
 } from '../types';
+import { PYTH_ENDPOINTS } from 'src/constants/pyth';
 
 /**
  * @description
@@ -81,13 +82,13 @@ export class ScallopUtils {
   /**
    * Request the scallop API to initialize data.
    *
-   * @param forece - Whether to force initialization.
+   * @param force - Whether to force initialization.
    */
-  public async init(forece: boolean = false) {
-    if (forece || !this._address.getAddresses()) {
+  public async init(force: boolean = false) {
+    if (force || !this._address.getAddresses()) {
       await this._address.read();
     }
-    await this._query.init(forece);
+    await this._query.init(force);
   }
 
   /**
@@ -391,25 +392,34 @@ export class ScallopUtils {
     }
 
     if (lackPricesCoinNames.length > 0) {
-      const pythConnection = new SuiPriceServiceConnection(
-        this.isTestnet
-          ? 'https://hermes-beta.pyth.network'
-          : 'https://hermes.pyth.network'
-      );
-      const priceIds = lackPricesCoinNames.map((coinName) =>
-        this._address.get(`core.coins.${coinName}.oracle.pyth.feed`)
-      );
+      const endpoints = PYTH_ENDPOINTS[this.isTestnet ? 'testnet' : 'mainnet'];
       try {
-        const priceFeeds =
-          (await pythConnection.getLatestPriceFeeds(priceIds)) || [];
-        for (const [index, feed] of priceFeeds.entries()) {
-          const data = parseDataFromPythPriceFeed(feed, this._address);
-          const coinName = lackPricesCoinNames[index];
-          this._priceMap.set(coinName, {
-            price: data.price,
-            publishTime: data.publishTime,
-          });
-          coinPrices[coinName] = data.price;
+        for (const endpoint of endpoints) {
+          try {
+            const pythConnection = new SuiPriceServiceConnection(endpoint);
+            const priceIds = lackPricesCoinNames.map((coinName) =>
+              this._address.get(`core.coins.${coinName}.oracle.pyth.feed`)
+            );
+            const priceFeeds =
+              (await pythConnection.getLatestPriceFeeds(priceIds)) || [];
+            for (const [index, feed] of priceFeeds.entries()) {
+              const data = parseDataFromPythPriceFeed(feed, this._address);
+              const coinName = lackPricesCoinNames[index];
+              this._priceMap.set(coinName, {
+                price: data.price,
+                publishTime: data.publishTime,
+              });
+              coinPrices[coinName] = data.price;
+            }
+
+            break;
+          } catch (e) {
+            console.warn(
+              `Failed to update price feeds with endpoint ${endpoint}: ${e}`
+            );
+          }
+
+          throw new Error('Failed to update price feeds with all endpoins');
         }
       } catch (_e) {
         for (const coinName of lackPricesCoinNames) {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -36,8 +36,11 @@ export type ScallopClientParams = ScallopParams & {
 
 export type ScallopBuilderParams = ScallopParams & {
   walletAddress?: string;
+  pythEndpoints?: string[];
 };
 
 export type ScallopQueryParams = ScallopParams;
 
-export type ScallopUtilsParams = ScallopParams;
+export type ScallopUtilsParams = ScallopParams & {
+  pythEndpoints?: string[];
+};


### PR DESCRIPTION
- Add multiple pyth endpoint for mainnet
- Iterate through endpoints list

### Note
The backup endpoint only accept request with `Origin: app.scallop.io` in the header. Need a way to test the endpoints iteration logic locally to ensure it work as expected before merging to master