### PR TITLE
feat: update veSCA builder unit tests

### DIFF
--- a/src/constants/vesca.ts
+++ b/src/constants/vesca.ts
@@ -1,5 +1,7 @@
+import { IS_VE_SCA_TEST } from './common';
+
 export const UNLOCK_ROUND_DURATION = 60 * 60 * 24; // 1 days in seconds
-export const MAX_LOCK_ROUNDS: number = 1460; // 4 years in days
+export const MAX_LOCK_ROUNDS: number = IS_VE_SCA_TEST ? 9 : 1460; // 4 years in days (or 9 days for testing)
 export const MAX_LOCK_DURATION: number =
   MAX_LOCK_ROUNDS * UNLOCK_ROUND_DURATION; // 4 years in seconds
 

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -50,7 +50,7 @@ export const checkLockSca = (
       const extendLockPeriodInSecond = lockPeriodInDays * UNLOCK_ROUND_DURATION;
       if (extendLockPeriodInSecond > MAX_LOCK_DURATION) {
         throw new Error(
-          `Maximum lock period is ~4 years (${MAX_LOCK_ROUNDS - 1} days)`
+          `Maximum lock period is ~4 years (${MAX_LOCK_ROUNDS} days)`
         );
       }
     } else {

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -50,7 +50,7 @@ export const checkLockSca = (
       const extendLockPeriodInSecond = lockPeriodInDays * UNLOCK_ROUND_DURATION;
       if (extendLockPeriodInSecond > MAX_LOCK_DURATION) {
         throw new Error(
-          `Maximum lock period is ~4 years (${MAX_LOCK_ROUNDS} days)`
+          `Maximum lock period is ~4 years (${MAX_LOCK_ROUNDS - 1} days)`
         );
       }
     } else {

--- a/test/builder.spec.ts
+++ b/test/builder.spec.ts
@@ -1,11 +1,6 @@
 import * as dotenv from 'dotenv';
 import { describe, it, expect } from 'vitest';
-import {
-  MAX_LOCK_ROUNDS,
-  SCA_COIN_TYPE,
-  SUPPORT_BORROW_INCENTIVE_REWARDS,
-  Scallop,
-} from '../src';
+import { MAX_LOCK_ROUNDS, SCA_COIN_TYPE, Scallop } from '../src';
 import { type NetworkType, TransactionBlock } from '@scallop-io/sui-kit';
 
 dotenv.config();
@@ -273,16 +268,8 @@ describe('Test Scallop Borrow Incentive Builder', async () => {
     const tx = scallopBuilder.createTxBlock();
     // Sender is required to invoke "claimQuick".
     tx.setSender(sender);
-    const rewardCoins = [];
-
-    for (const rewardCoinName of SUPPORT_BORROW_INCENTIVE_REWARDS) {
-      const rewardCoin = await tx.claimBorrowIncentiveQuick(
-        'sui',
-        rewardCoinName
-      );
-      rewardCoins.push(rewardCoin);
-    }
-    tx.transferObjects(rewardCoins, sender);
+    const rewardCoin = await tx.claimBorrowIncentiveQuick('sui', 'sca');
+    tx.transferObjects([rewardCoin], sender);
     const claimBorrowIncentiveQuickResult =
       await scallopBuilder.suiKit.inspectTxn(tx);
     if (ENABLE_LOG) {


### PR DESCRIPTION
- Update the veSCA builder tests
- Make sure to set `IS_VE_SCA_TEST` to `false` in `src/constants/common.ts` before testing it
- Make sure the wallet address has >= 10 test SCA
- run `pnpm run test:unit -t 'Test Scallop VeSca Builder'`