### PR TITLE
refactor: return veSCA with highest balance

### DIFF
--- a/src/builders/vescaBuilder.ts
+++ b/src/builders/vescaBuilder.ts
@@ -65,7 +65,11 @@ export const requireVeSca = async (
     return undefined;
   }
 
-  return veScas[0];
+  return veScas.reduce(
+    (prev, acc) =>
+      acc.currentVeScaBalance > prev.currentVeScaBalance ? acc : prev,
+    veScas[0]
+  ); // return veSCA with highest veSCA balance
 };
 
 /**
@@ -228,7 +232,7 @@ const generateQuickVeScaMethod: GenerateVeScaQuickMethod = ({
             transferObjects.push(veScaKey);
           } else {
             // user must withdraw current unlocked SCA first if any
-            if (veSca.lockedScaAmount !== 0) {
+            if (veSca.lockedScaCoin !== 0) {
               const unlockedSca = txBlock.redeemSca(veSca.keyId);
               transferObjects.push(unlockedSca);
             }
@@ -309,7 +313,7 @@ const generateQuickVeScaMethod: GenerateVeScaQuickMethod = ({
 
       if (veSca) {
         const transferObjects = [];
-        if (veSca.lockedScaAmount !== 0) {
+        if (veSca.lockedScaCoin !== 0) {
           const unlockedSca = txBlock.redeemSca(veSca.keyId);
           transferObjects.push(unlockedSca);
         }

--- a/src/queries/vescaQuery.ts
+++ b/src/queries/vescaQuery.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { Vesca } from '../types';
 import type { SuiObjectResponse, SuiObjectData } from '@mysten/sui.js/client';
 import type { ScallopQuery } from '../models';
-import { IS_VE_SCA_TEST } from 'src/constants';
+import { IS_VE_SCA_TEST, MAX_LOCK_DURATION } from 'src/constants';
 /**
  * Query all owned veSca key.
  *
@@ -109,13 +109,26 @@ export const getVeSca = async (
   ) {
     const dynamicFields = (veScaDynamicFieldObject.content.fields as any).value
       .fields;
+
+    const remainingLockPeriodInMilliseconds = Math.max(
+      +dynamicFields.unlock_at * 1000 - Date.now(),
+      0
+    );
+    const lockedScaAmount = String(dynamicFields.locked_sca_amount);
+    const lockedScaCoin = BigNumber(dynamicFields.locked_sca_amount)
+      .shiftedBy(-9)
+      .toNumber();
+    const currentVeScaBalance =
+      lockedScaCoin *
+      (Math.floor(remainingLockPeriodInMilliseconds / 1000) /
+        MAX_LOCK_DURATION);
+
     vesca = {
       id: veScaDynamicFieldObject.objectId,
       keyId: veScaKeyId,
-      lockedScaAmount: BigNumber(dynamicFields.locked_sca_amount).toNumber(),
-      lockedScaCoin: BigNumber(dynamicFields.locked_sca_amount)
-        .shiftedBy(-9)
-        .toNumber(),
+      lockedScaAmount,
+      lockedScaCoin,
+      currentVeScaBalance,
       unlockAt: BigNumber(dynamicFields.unlock_at).toNumber(),
     } as Vesca;
   }

--- a/src/types/query/vesca.ts
+++ b/src/types/query/vesca.ts
@@ -1,7 +1,8 @@
 export type Vesca = {
   id: string;
   keyId: string;
-  lockedScaAmount: number;
+  lockedScaAmount: string;
   lockedScaCoin: number;
+  currentVeScaBalance: number;
   unlockAt: number;
 };


### PR DESCRIPTION
### Old Behavior
- `requireVeSca` return the first element of `veScas` array if no veScaKey is supplied

### New Behavior
- `requireVeSca` return veSca with the highest balance if no veScaKey is supplied