### PR TITLE
feat: optimize get coin implementation

### DIFF
--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -108,8 +108,8 @@ export const getLending = async (
   marketPool?: MarketPool,
   spool?: Spool,
   stakeAccounts?: StakeAccount[],
-  coinAmount?: number,
-  marketCoinAmount?: number,
+  coinAmount?: string,
+  marketCoinAmount?: string,
   coinPrice?: number
 ) => {
   const marketCoinName = query.utils.parseMarketCoinName(poolCoinName);

--- a/src/types/query/core.ts
+++ b/src/types/query/core.ts
@@ -13,9 +13,9 @@ export type MarketPools = OptionalKeys<Record<SupportPoolCoins, MarketPool>>;
 export type MarketCollaterals = OptionalKeys<
   Record<SupportCollateralCoins, MarketCollateral>
 >;
-export type CoinAmounts = OptionalKeys<Record<SupportPoolCoins, number>>;
+export type CoinAmounts = OptionalKeys<Record<SupportPoolCoins, string>>;
 export type MarketCoinAmounts = OptionalKeys<
-  Record<SupportMarketCoins, number>
+  Record<SupportMarketCoins, string>
 >;
 
 export type BalanceSheet = {


### PR DESCRIPTION
### CHANGES
Instead of querying the coin objects one by one, we use `getAllBalance` RPC calls to get all coins balance, and then access it individually by its coin type. This greatly reduce the required RPC calls to get coin balance