### PR TITLE
fix: getLending parameters order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.46.42](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.41...v0.46.42) (2024-07-08)
+
+### Bugfixes
+
+- Fix `getLending` parameters order ([f71217b](https://github.com/scallop-io/sui-scallop-sdk/pull/135/commits/f71217b77199fc13187183fb21a8afa231226a2d))
+
 ### [0.46.41](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.40...v0.46.41) (2024-07-05)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "0.46.41",
+  "version": "0.46.42",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -119,8 +119,8 @@ export const getLending = async (
   stakeAccounts?: StakeAccount[],
   coinAmount?: number,
   marketCoinAmount?: number,
-  sCoinAmount?: number,
-  coinPrice?: number
+  coinPrice?: number,
+  sCoinAmount?: number
 ) => {
   const marketCoinName = query.utils.parseMarketCoinName(poolCoinName);
   marketPool = marketPool || (await query.getMarketPool(poolCoinName, indexer));


### PR DESCRIPTION
### CHANGES
- Fix `getLending` parameters order ([f71217b](https://github.com/scallop-io/sui-scallop-sdk/pull/135/commits/f71217b77199fc13187183fb21a8afa231226a2d))