### PR TITLE
fix: plus sCoinAmount into unstakedMarketAmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.46.43](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.42...v0.46.43) (2024-07-09)
+
+### Bugfixes
+
+- Minor fix on `unstakedMarketAmount` ([faa647d](https://github.com/scallop-io/sui-scallop-sdk/pull/136/commits/faa647d7eac2518a71fb12eb4060bdf42c9d2ceb))
+
 ### [0.46.42](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.41...v0.46.42) (2024-07-08)
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "0.46.42",
+  "version": "0.46.43",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -219,7 +219,9 @@ export const getLending = async (
   const marketCoinPrice = BigNumber(coinPrice ?? 0).multipliedBy(
     marketPool?.conversionRate ?? 1
   );
-  const unstakedMarketAmount = BigNumber(marketCoinAmount);
+  const unstakedMarketAmount = BigNumber(marketCoinAmount).plus(
+    BigNumber(sCoinAmount)
+  );
   const unstakedMarketCoin = unstakedMarketAmount.shiftedBy(-1 * coinDecimal);
 
   const availableSupplyAmount = BigNumber(coinAmount);


### PR DESCRIPTION
### CHANGES
- Minor fix on `unstakedMarketAmount` ([faa647d](https://github.com/scallop-io/sui-scallop-sdk/pull/136/commits/faa647d7eac2518a71fb12eb4060bdf42c9d2ceb))