### PR TITLE
Refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.46.50](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.49...v0.46.50) (2024-07-30)
+
+### Bugfixes
+
+- Fix reward apr for borrow incentive when point is 0 ([64c924f](https://github.com/scallop-io/sui-scallop-sdk/pull/146/commits/64c924fa38f603efc15739436e52d0e700fa1c32))
+
+### Features
+
+- Add `walletAddress` property to `ScallopQuery` instance ([94d8396](https://github.com/scallop-io/sui-scallop-sdk/pull/146/commits/94d839684f865d5dfc3fd7dac9abfde634825d1b))
+- Optimize `getPythPrices` function ([d75234b](https://github.com/scallop-io/sui-scallop-sdk/pull/146/commits/d75234b190afdd89c9d749d861d2fdf3aad9a38f))
+
+
 ### [0.46.49](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.48...v0.46.49) (2024-07-12)
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "0.46.49",
+  "version": "0.46.50",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/models/scallopBuilder.ts
+++ b/src/models/scallopBuilder.ts
@@ -122,7 +122,7 @@ export class ScallopBuilder {
     txBlock: ScallopTxBlock | SuiKitTxBlock,
     assetCoinName: SupportAssetCoins,
     amount: number,
-    sender: string
+    sender: string = this.walletAddress
   ) {
     const coinType = this.utils.parseCoinType(assetCoinName);
     const coins = await this.utils.selectCoins(amount, coinType, sender);
@@ -143,7 +143,7 @@ export class ScallopBuilder {
     txBlock: ScallopTxBlock | SuiKitTxBlock,
     marketCoinName: SupportMarketCoins,
     amount: number,
-    sender: string
+    sender: string = this.walletAddress
   ) {
     const marketCoinType = this.utils.parseMarketCoinType(marketCoinName);
     const coins = await this.utils.selectCoins(amount, marketCoinType, sender);
@@ -171,7 +171,7 @@ export class ScallopBuilder {
     txBlock: ScallopTxBlock | SuiKitTxBlock,
     sCoinName: SupportSCoin,
     amount: number,
-    sender: string
+    sender: string = this.walletAddress
   ) {
     const sCoinType = this.utils.parseSCoinType(sCoinName);
     const coins = await this.utils.selectCoins(amount, sCoinType, sender);

--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -52,12 +52,13 @@ import { ScallopUtils } from './scallopUtils';
 import { ScallopIndexer } from './scallopIndexer';
 import { ScallopCache } from './scallopCache';
 import { DEFAULT_CACHE_OPTIONS } from 'src/constants/cache';
-import { SuiObjectData } from '@mysten/sui.js/src/client';
+import { SuiObjectData } from '@mysten/sui.js/client';
 import {
   getSCoinAmount,
   getSCoinAmounts,
   getSCoinTotalSupply,
 } from 'src/queries/sCoinQuery';
+import { normalizeSuiAddress } from '@mysten/sui.js/utils';
 
 /**
  * @description
@@ -79,6 +80,7 @@ export class ScallopQuery {
   public utils: ScallopUtils;
   public indexer: ScallopIndexer;
   public cache: ScallopCache;
+  public walletAddress: string;
 
   public constructor(
     params: ScallopQueryParams,
@@ -106,6 +108,9 @@ export class ScallopQuery {
         query: this,
       });
     this.indexer = new ScallopIndexer(this.params, { cache: this.cache });
+    this.walletAddress = normalizeSuiAddress(
+      params?.walletAddress || this.suiKit.currentAddress()
+    );
   }
 
   /**
@@ -205,7 +210,7 @@ export class ScallopQuery {
    * @param ownerAddress - The owner address.
    * @return Obligations data.
    */
-  public async getObligations(ownerAddress?: string) {
+  public async getObligations(ownerAddress: string = this.walletAddress) {
     return await getObligations(this, ownerAddress);
   }
 
@@ -228,7 +233,7 @@ export class ScallopQuery {
    */
   public async getCoinAmounts(
     assetCoinNames?: SupportAssetCoins[],
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     return await getCoinAmounts(this, assetCoinNames, ownerAddress);
   }
@@ -242,7 +247,7 @@ export class ScallopQuery {
    */
   public async getCoinAmount(
     assetCoinName: SupportAssetCoins,
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     return await getCoinAmount(this, assetCoinName, ownerAddress);
   }
@@ -256,7 +261,7 @@ export class ScallopQuery {
    */
   public async getMarketCoinAmounts(
     marketCoinNames?: SupportMarketCoins[],
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     return await getMarketCoinAmounts(this, marketCoinNames, ownerAddress);
   }
@@ -270,7 +275,7 @@ export class ScallopQuery {
    */
   public async getMarketCoinAmount(
     marketCoinName: SupportMarketCoins,
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     return await getMarketCoinAmount(this, marketCoinName, ownerAddress);
   }
@@ -331,7 +336,7 @@ export class ScallopQuery {
    * @param ownerAddress - The owner address.
    * @return All Stake accounts data.
    */
-  public async getAllStakeAccounts(ownerAddress?: string) {
+  public async getAllStakeAccounts(ownerAddress: string = this.walletAddress) {
     return await getStakeAccounts(this, ownerAddress);
   }
 
@@ -344,7 +349,7 @@ export class ScallopQuery {
    */
   public async getStakeAccounts(
     stakeMarketCoinName: SupportStakeMarketCoins,
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     const allStakeAccount = await this.getAllStakeAccounts(ownerAddress);
     return allStakeAccount[stakeMarketCoinName] ?? [];
@@ -472,7 +477,7 @@ export class ScallopQuery {
    */
   public async getLendings(
     poolCoinNames?: SupportPoolCoins[],
-    ownerAddress?: string,
+    ownerAddress: string = this.walletAddress,
     indexer: boolean = false
   ) {
     return await getLendings(this, poolCoinNames, ownerAddress, indexer);
@@ -488,7 +493,7 @@ export class ScallopQuery {
    */
   public async getLending(
     poolCoinName: SupportPoolCoins,
-    ownerAddress?: string,
+    ownerAddress: string = this.walletAddress,
     indexer: boolean = false
   ) {
     return await getLending(this, poolCoinName, ownerAddress, indexer);
@@ -505,7 +510,7 @@ export class ScallopQuery {
    * @return All obligation accounts information.
    */
   public async getObligationAccounts(
-    ownerAddress?: string,
+    ownerAddress: string = this.walletAddress,
     indexer: boolean = false
   ) {
     return await getObligationAccounts(this, ownerAddress, indexer);
@@ -524,7 +529,7 @@ export class ScallopQuery {
    */
   public async getObligationAccount(
     obligationId: string,
-    ownerAddress?: string,
+    ownerAddress: string = this.walletAddress,
     indexer: boolean = false
   ) {
     return await getObligationAccount(
@@ -619,7 +624,7 @@ export class ScallopQuery {
    */
   public async getSCoinAmounts(
     sCoinNames?: SupportSCoin[],
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     return await getSCoinAmounts(this, sCoinNames, ownerAddress);
   }
@@ -633,7 +638,7 @@ export class ScallopQuery {
    */
   public async getSCoinAmount(
     sCoinName: SupportSCoin | SupportMarketCoins,
-    ownerAddress?: string
+    ownerAddress: string = this.walletAddress
   ) {
     const parsedSCoinName = this.utils.parseSCoinName(sCoinName);
     return parsedSCoinName

--- a/src/queries/loyaltyProgramQuery.ts
+++ b/src/queries/loyaltyProgramQuery.ts
@@ -1,4 +1,4 @@
-import { SuiObjectData } from '@mysten/sui.js/src/client';
+import { SuiObjectData } from '@mysten/sui.js/client';
 import BigNumber from 'bignumber.js';
 import { ScallopQuery } from 'src/models';
 import { LoyaltyProgramInfo } from 'src/types';

--- a/src/queries/priceQuery.ts
+++ b/src/queries/priceQuery.ts
@@ -1,4 +1,4 @@
-import { SuiObjectData } from '@mysten/sui.js/src/client';
+import { SuiObjectData } from '@mysten/sui.js/client';
 import type { ScallopQuery } from '../models';
 import type { SupportAssetCoins } from '../types';
 

--- a/src/queries/priceQuery.ts
+++ b/src/queries/priceQuery.ts
@@ -76,7 +76,7 @@ export const getPythPrices = async (
     {} as Record<string, SupportAssetCoins[]>
   );
 
-  // Fecth multiple objects at once to save rpc calls
+  // Fetch multiple objects at once to save rpc calls
   const priceFeedObjects = await query.cache.queryGetObjects(
     Object.keys(pythPriceFeedIds),
     { showContent: true }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -41,7 +41,9 @@ export type ScallopBuilderParams = ScallopParams & {
   pythEndpoints?: string[];
 };
 
-export type ScallopQueryParams = ScallopParams;
+export type ScallopQueryParams = ScallopParams & {
+  walletAddress?: string;
+};
 
 export type ScallopUtilsParams = ScallopParams & {
   pythEndpoints?: string[];

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -512,23 +512,25 @@ export const calculateBorrowIncentivePoolPointData = (
     .multipliedBy(rewardCoinPrice);
 
   const weightScale = BigNumber(1_000_000_000_000);
-  const rewardRate = rewardValueForYear
-    .multipliedBy(
-      BigNumber(parsedBorrowIncentivePoolPointData.baseWeight).dividedBy(
-        weightScale
-      )
-    )
-    .dividedBy(weightedStakedValue)
-    .isFinite()
-    ? rewardValueForYear
-        .multipliedBy(
-          BigNumber(parsedBorrowIncentivePoolPointData.baseWeight).dividedBy(
-            weightScale
-          )
+
+  const rewardRate =
+    rewardValueForYear
+      .multipliedBy(
+        BigNumber(parsedBorrowIncentivePoolPointData.baseWeight).dividedBy(
+          weightScale
         )
-        .dividedBy(weightedStakedValue)
-        .toNumber()
-    : Infinity;
+      )
+      .dividedBy(weightedStakedValue)
+      .isFinite() && parsedBorrowIncentivePoolPointData.points > 0
+      ? rewardValueForYear
+          .multipliedBy(
+            BigNumber(parsedBorrowIncentivePoolPointData.baseWeight).dividedBy(
+              weightScale
+            )
+          )
+          .dividedBy(weightedStakedValue)
+          .toNumber()
+      : Infinity;
 
   return {
     distributedPointPerSec: distributedPointPerSec.toNumber(),


### PR DESCRIPTION
### CHANGES
- Optimize the `getPythPrices` function by reducing objects rpc query call
- Refactor the `scallopQuery` class to have `walletAddress` property
- Default all `ownerAddress` parameter of query method to `this.walletAddress`
- Default all `sender` parameter of builder method to `this.walletAddress`
- Fix reward apr for borrow incentive when point is 0