### PR TITLE
fix: stakeHelper and migrateAllMarketCoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.46.53](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.52...v0.46.53) (2024-08-01)
+
+### Bugfixes
+
+- `stakeHelper` function, handle stake spool when user has old marketCoin and new sCoin ([5911caf](https://github.com/scallop-io/sui-scallop-sdk/pull/150/commits/5911caf00373e085a7dead3d1f557f8ec4390bf9))
+
+- minor fix on `migrateAllMarketCoin` ([49da8b8](https://github.com/scallop-io/sui-scallop-sdk/pull/150/commits/49da8b860d5f12d32ff2cf03cec14082206f04b8)) ([04e777f](https://github.com/scallop-io/sui-scallop-sdk/pull/150/commits/04e777f492355d76002ffa66f3a4c6c5da340037))
+
 ### [0.46.52](https://github.com/scallop-io/sui-scallop-sdk/compare/v0.46.51...v0.46.52) (2024-07-31)
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "0.46.52",
+  "version": "0.46.53",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -991,12 +991,10 @@ export class ScallopClient {
             this.walletAddress
           ); // throw error no coins found
 
-          const mergedMarketCoin = marketCoins[0];
+          const toDestroyMarketCoin = marketCoins[0];
           if (marketCoins.length > 1) {
-            txBlock.mergeCoins(mergedMarketCoin, marketCoins.slice(1));
+            txBlock.mergeCoins(toDestroyMarketCoin, marketCoins.slice(1));
           }
-
-          toDestroyMarketCoin = mergedMarketCoin;
         } catch (e: any) {
           // Ignore
           const errMsg = e.toString() as String;
@@ -1018,23 +1016,13 @@ export class ScallopClient {
               Number.MAX_SAFE_INTEGER,
               this.utils.parseSCoinType(sCoinName as SupportSCoin),
               this.walletAddress
-            ); // throw error on no coins found
-            const mergedSCoin = existSCoins[0];
-            if (existSCoins.length > 1) {
-              txBlock.mergeCoins(mergedSCoin, existSCoins.slice(1));
-            }
-
-            // merge existing sCoin to new sCoin
-            txBlock.mergeCoins(sCoin, [mergedSCoin]);
+            );
+            txBlock.mergeCoins(sCoin, existSCoins);
           } catch (e: any) {
             // ignore
-            const errMsg = e.toString() as String;
-            if (!errMsg.includes('No valid coins found for the transaction'))
-              throw e;
           }
           sCoins.push(sCoin);
         }
-
         // check for staked market coin in spool
         if (SUPPORT_SPOOLS.includes(sCoinName as SupportStakeMarketCoins)) {
           try {
@@ -1047,8 +1035,6 @@ export class ScallopClient {
             }
           } catch (e: any) {
             // ignore
-            const errMsg = e.toString();
-            if (!errMsg.includes('No stake account found')) throw e;
           }
         }
 

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -991,7 +991,7 @@ export class ScallopClient {
             this.walletAddress
           ); // throw error no coins found
 
-          const toDestroyMarketCoin = marketCoins[0];
+          toDestroyMarketCoin = marketCoins[0];
           if (marketCoins.length > 1) {
             txBlock.mergeCoins(toDestroyMarketCoin, marketCoins.slice(1));
           }


### PR DESCRIPTION
### CHANGES
- `stakeHelper` function, handle stake spool when user has old marketCoin and new sCoin ([5911caf](https://github.com/scallop-io/sui-scallop-sdk/pull/150/commits/5911caf00373e085a7dead3d1f557f8ec4390bf9))

- minor fix on `migrateAllMarketCoin` ([49da8b8](https://github.com/scallop-io/sui-scallop-sdk/pull/150/commits/49da8b860d5f12d32ff2cf03cec14082206f04b8)) ([04e777f](https://github.com/scallop-io/sui-scallop-sdk/pull/150/commits/04e777f492355d76002ffa66f3a4c6c5da340037))