### PR TITLE
Refactor structure

### DIFF
--- a/src/builders/borrowIncentiveBuilder.ts
+++ b/src/builders/borrowIncentiveBuilder.ts
@@ -51,13 +51,13 @@ const requireObligationInfo = async (
     typeof obligationId === 'string'
   ) {
     const obligationLocked = await getObligationLocked(
-      builder.query,
+      builder.cache,
       obligationId
     );
     return { obligationId, obligationKey, obligationLocked };
   }
   const sender = requireSender(txBlock);
-  const obligations = await getObligations(builder.query, sender);
+  const obligations = await getObligations(builder, sender);
   if (obligations.length === 0) {
     throw new Error(`No obligation found for sender ${sender}`);
   }
@@ -260,7 +260,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
           const veSca = await requireVeSca(builder, txBlock, veScaKey);
           if (veSca) {
             const bindedObligationId = await getBindedObligationId(
-              builder.query,
+              builder,
               veSca.keyId
             );
 

--- a/src/builders/borrowIncentiveBuilder.ts
+++ b/src/builders/borrowIncentiveBuilder.ts
@@ -207,7 +207,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
       stakeObligationQuick: async (obligation, obligationKey) => {
         const {
           obligationId: obligationArg,
-          obligationKey: obligationtKeyArg,
+          obligationKey: obligationKeyArg,
           obligationLocked: obligationLocked,
         } = await requireObligationInfo(
           builder,
@@ -227,7 +227,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
           );
 
         if (!obligationLocked || unstakeObligationBeforeStake) {
-          txBlock.stakeObligation(obligationArg, obligationtKeyArg);
+          txBlock.stakeObligation(obligationArg, obligationKeyArg);
         }
       },
       stakeObligationWithVeScaQuick: async (
@@ -237,7 +237,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
       ) => {
         const {
           obligationId: obligationArg,
-          obligationKey: obligationtKeyArg,
+          obligationKey: obligationKeyArg,
           obligationLocked: obligationLocked,
         } = await requireObligationInfo(
           builder,
@@ -271,21 +271,21 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
             ) {
               txBlock.stakeObligationWithVesca(
                 obligationArg,
-                obligationtKeyArg,
+                obligationKeyArg,
                 veSca.keyId
               );
             } else {
-              txBlock.stakeObligation(obligationArg, obligationtKeyArg);
+              txBlock.stakeObligation(obligationArg, obligationKeyArg);
             }
           } else {
-            txBlock.stakeObligation(obligationArg, obligationtKeyArg);
+            txBlock.stakeObligation(obligationArg, obligationKeyArg);
           }
         }
       },
       unstakeObligationQuick: async (obligation, obligationKey) => {
         const {
           obligationId: obligationArg,
-          obligationKey: obligationtKeyArg,
+          obligationKey: obligationKeyArg,
           obligationLocked: obligationLocked,
         } = await requireObligationInfo(
           builder,
@@ -295,7 +295,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
         );
 
         if (obligationLocked) {
-          txBlock.unstakeObligation(obligationArg, obligationtKeyArg);
+          txBlock.unstakeObligation(obligationArg, obligationKeyArg);
         }
       },
       claimBorrowIncentiveQuick: async (
@@ -304,19 +304,17 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
         obligation,
         obligationKey
       ) => {
-        const {
-          obligationId: obligationArg,
-          obligationKey: obligationtKeyArg,
-        } = await requireObligationInfo(
-          builder,
-          txBlock,
-          obligation,
-          obligationKey
-        );
+        const { obligationId: obligationArg, obligationKey: obligationKeyArg } =
+          await requireObligationInfo(
+            builder,
+            txBlock,
+            obligation,
+            obligationKey
+          );
 
         return txBlock.claimBorrowIncentive(
           obligationArg,
-          obligationtKeyArg,
+          obligationKeyArg,
           coinName,
           rewardCoinName
         );

--- a/src/builders/coreBuilder.ts
+++ b/src/builders/coreBuilder.ts
@@ -391,10 +391,11 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
         obligationId,
         obligationKey
       );
-      const obligationCoinNames = await builder.utils.getObligationCoinNames(
-        obligationInfo.obligationId
-      );
-      const updateCoinNames = [...obligationCoinNames, poolCoinName];
+      const obligationCoinNames =
+        (await builder.utils.getObligationCoinNames(
+          obligationInfo.obligationId
+        )) ?? [];
+      const updateCoinNames = [...(obligationCoinNames ?? []), poolCoinName];
       await updateOracles(builder, txBlock, updateCoinNames);
       return txBlock.borrow(
         obligationInfo.obligationId,
@@ -416,9 +417,10 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
         obligationId,
         obligationKey
       );
-      const obligationCoinNames = await builder.utils.getObligationCoinNames(
-        obligationInfo.obligationId
-      );
+      const obligationCoinNames =
+        (await builder.utils.getObligationCoinNames(
+          obligationInfo.obligationId
+        )) ?? [];
       const updateCoinNames = [...obligationCoinNames, poolCoinName];
       await updateOracles(builder, txBlock, updateCoinNames);
       return txBlock.borrowWithReferral(

--- a/src/builders/coreBuilder.ts
+++ b/src/builders/coreBuilder.ts
@@ -44,7 +44,7 @@ const requireObligationInfo = async (
   if (params.length === 4 && obligationId && obligationKey)
     return { obligationId, obligationKey };
   const sender = requireSender(txBlock);
-  const obligations = await getObligations(builder.query, sender);
+  const obligations = await getObligations(builder, sender);
   if (obligations.length === 0) {
     throw new Error(`No obligation found for sender ${sender}`);
   }

--- a/src/builders/spoolBuilder.ts
+++ b/src/builders/spoolBuilder.ts
@@ -42,7 +42,7 @@ const requireStakeAccountIds = async (
   const [builder, txBlock, stakeMarketCoinName, stakeAccountId] = params;
   if (params.length === 4 && stakeAccountId) return [stakeAccountId];
   const sender = requireSender(txBlock);
-  const stakeAccounts = await getStakeAccounts(builder.query, sender);
+  const stakeAccounts = await getStakeAccounts(builder, sender);
   if (stakeAccounts[stakeMarketCoinName].length === 0) {
     throw new Error(`No stake account id found for sender ${sender}`);
   }
@@ -72,7 +72,7 @@ const requireStakeAccounts = async (
 ) => {
   const [builder, txBlock, stakeMarketCoinName, stakeAccountId] = params;
   const sender = requireSender(txBlock);
-  const stakeAccounts = await getStakeAccounts(builder.query, sender);
+  const stakeAccounts = await getStakeAccounts(builder, sender);
   if (stakeAccounts[stakeMarketCoinName].length === 0) {
     throw new Error(`No stake account found for sender ${sender}`);
   }

--- a/src/builders/vescaBuilder.ts
+++ b/src/builders/vescaBuilder.ts
@@ -50,7 +50,7 @@ export const requireVeSca = async (
 ) => {
   const [builder, txBlock, veScaKey] = params;
   if (params.length === 3 && veScaKey && typeof veScaKey === 'string') {
-    const veSca = await getVeSca(builder.query, veScaKey);
+    const veSca = await getVeSca(builder.utils, veScaKey);
 
     if (!veSca) {
       return undefined;
@@ -60,7 +60,7 @@ export const requireVeSca = async (
   }
 
   const sender = requireSender(txBlock);
-  const veScas = await getVeScas(builder.query, sender);
+  const veScas = await getVeScas(builder, sender);
   if (veScas.length === 0) {
     return undefined;
   }

--- a/src/constants/pyth.ts
+++ b/src/constants/pyth.ts
@@ -1,6 +1,6 @@
 export const PYTH_ENDPOINTS: {
-  [k in 'mainnet' | 'testnet']: Readonly<string[]>;
+  [k in 'mainnet' | 'testnet']: string[];
 } = {
   testnet: ['https://hermes-beta.pyth.network'],
   mainnet: ['https://hermes.pyth.network', 'https://scallop.rpc.p2p.world'],
-} as const;
+};

--- a/src/models/scallopBuilder.ts
+++ b/src/models/scallopBuilder.ts
@@ -9,12 +9,12 @@ import type { SuiTransactionBlockResponse } from '@mysten/sui.js/client';
 import type { TransactionBlock } from '@mysten/sui.js/transactions';
 import type { SuiTxBlock as SuiKitTxBlock } from '@scallop-io/sui-kit';
 import type {
-  ScallopInstanceParams,
   ScallopBuilderParams,
   ScallopTxBlock,
   SupportMarketCoins,
   SupportAssetCoins,
   SupportSCoin,
+  ScallopBuilderInstanceParams,
 } from '../types';
 import { ScallopCache } from './scallopCache';
 import { DEFAULT_CACHE_OPTIONS } from 'src/constants/cache';
@@ -43,39 +43,43 @@ export class ScallopBuilder {
 
   public constructor(
     params: ScallopBuilderParams,
-    instance?: ScallopInstanceParams
+    instance?: ScallopBuilderInstanceParams
   ) {
-    this.params = params;
     this.suiKit = instance?.suiKit ?? new SuiKit(params);
-    this.cache =
-      instance?.cache ?? new ScallopCache(DEFAULT_CACHE_OPTIONS, this.suiKit);
-    this.address =
-      instance?.address ??
-      new ScallopAddress(
+
+    this.params = params;
+    this.walletAddress = normalizeSuiAddress(
+      params?.walletAddress || this.suiKit.currentAddress()
+    );
+
+    if (instance?.query) {
+      this.query = instance.query;
+      this.utils = this.query.utils;
+      this.address = this.utils.address;
+      this.cache = this.address.cache;
+    } else {
+      this.cache = new ScallopCache(this.suiKit, DEFAULT_CACHE_OPTIONS);
+      this.address = new ScallopAddress(
         {
           id: params?.addressesId || ADDRESSES_ID,
           network: params?.networkType,
         },
-        this.cache
+        {
+          cache: this.cache,
+        }
       );
-    this.query =
-      instance?.query ??
-      new ScallopQuery(params, {
-        suiKit: this.suiKit,
+      this.utils = new ScallopUtils(this.params, {
         address: this.address,
-        cache: this.cache,
       });
-    this.utils =
-      instance?.utils ??
-      new ScallopUtils(this.params, {
-        suiKit: this.suiKit,
-        address: this.address,
-        query: this.query,
-        cache: this.cache,
-      });
-    this.walletAddress = normalizeSuiAddress(
-      params?.walletAddress || this.suiKit.currentAddress()
-    );
+      this.query = new ScallopQuery(
+        {
+          walletAddress: this.walletAddress,
+        },
+        {
+          utils: this.utils,
+        }
+      );
+    }
     this.isTestnet = params.networkType
       ? params.networkType === 'testnet'
       : false;

--- a/src/models/scallopCache.ts
+++ b/src/models/scallopCache.ts
@@ -46,12 +46,12 @@ type QueryInspectTxnParams = {
 
 export class ScallopCache {
   public readonly queryClient: QueryClient;
-  public readonly _suiKit?: SuiKit;
+  public readonly _suiKit: SuiKit;
   private tokenBucket: TokenBucket;
 
   public constructor(
+    suiKit: SuiKit,
     cacheOptions?: QueryClientConfig,
-    suiKit?: SuiKit,
     tokenBucket?: TokenBucket
   ) {
     this.queryClient = new QueryClient(cacheOptions ?? DEFAULT_CACHE_OPTIONS);

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -19,7 +19,6 @@ import type { TransactionObjectArgument } from '@mysten/sui.js/transactions';
 import type { SuiObjectArg } from '@scallop-io/sui-kit';
 import type {
   ScallopClientFnReturnType,
-  ScallopInstanceParams,
   ScallopClientParams,
   SupportPoolCoins,
   SupportCollateralCoins,
@@ -29,6 +28,7 @@ import type {
   SupportBorrowIncentiveCoins,
   ScallopTxBlock,
   SupportSCoin,
+  ScallopClientInstanceParams,
 } from '../types';
 
 /**
@@ -56,48 +56,42 @@ export class ScallopClient {
 
   public constructor(
     params: ScallopClientParams,
-    instance?: ScallopInstanceParams
+    instance?: ScallopClientInstanceParams
   ) {
     this.params = params;
-    this.suiKit = instance?.suiKit ?? new SuiKit(params);
-    this.cache =
-      instance?.cache ?? new ScallopCache(DEFAULT_CACHE_OPTIONS, this.suiKit);
-    this.address =
-      instance?.address ??
-      new ScallopAddress(
+    this.suiKit =
+      instance?.suiKit ?? instance?.builder?.suiKit ?? new SuiKit(params);
+    this.walletAddress = normalizeSuiAddress(
+      params?.walletAddress || this.suiKit.currentAddress()
+    );
+
+    if (instance?.builder) {
+      this.builder = instance.builder;
+      this.query = this.builder.query;
+      this.utils = this.query.utils;
+      this.address = this.utils.address;
+      this.cache = this.address.cache;
+    } else {
+      this.cache = new ScallopCache(this.suiKit, DEFAULT_CACHE_OPTIONS);
+      this.address = new ScallopAddress(
         {
           id: params?.addressesId || ADDRESSES_ID,
           network: params?.networkType,
         },
-        this.cache
+        {
+          cache: this.cache,
+        }
       );
-    this.query =
-      instance?.query ??
-      new ScallopQuery(params, {
-        suiKit: this.suiKit,
+      this.utils = new ScallopUtils(this.params, {
         address: this.address,
-        cache: this.cache,
       });
-    this.utils =
-      instance?.utils ??
-      new ScallopUtils(params, {
-        suiKit: this.suiKit,
-        address: this.address,
-        query: this.query,
-        cache: this.cache,
-      });
-    this.builder =
-      instance?.builder ??
-      new ScallopBuilder(params, {
-        suiKit: this.suiKit,
-        address: this.address,
-        query: this.query,
+      this.query = new ScallopQuery(this.params, {
         utils: this.utils,
-        cache: this.cache,
       });
-    this.walletAddress = normalizeSuiAddress(
-      params?.walletAddress || this.suiKit.currentAddress()
-    );
+      this.builder = new ScallopBuilder(this.params, {
+        query: this.query,
+      });
+    }
   }
 
   /**

--- a/src/models/scallopIndexer.ts
+++ b/src/models/scallopIndexer.ts
@@ -17,11 +17,13 @@ import type {
   TotalValueLocked,
   ScallopQueryParams,
   ScallopParams,
-  ScallopInstanceParams,
   BorrowIncentivePoolPoints,
   SupportBorrowIncentiveRewardCoins,
+  ScallopIndexerInstanceParams,
 } from '../types';
 import { ScallopCache } from './scallopCache';
+import { DEFAULT_CACHE_OPTIONS } from 'src/constants/cache';
+import { SuiKit } from '@scallop-io/sui-kit';
 
 /**
  * @description
@@ -36,13 +38,18 @@ import { ScallopCache } from './scallopCache';
  * ```
  */
 export class ScallopIndexer {
-  private readonly _cache: ScallopCache;
+  private readonly cache: ScallopCache;
   public readonly params: ScallopQueryParams;
   private readonly _requestClient: AxiosInstance;
 
-  public constructor(params: ScallopParams, instance?: ScallopInstanceParams) {
+  public constructor(
+    params: ScallopParams,
+    instance?: ScallopIndexerInstanceParams
+  ) {
     this.params = params;
-    this._cache = instance?.cache ?? new ScallopCache();
+    this.cache =
+      instance?.cache ??
+      new ScallopCache(new SuiKit({}), DEFAULT_CACHE_OPTIONS);
     this._requestClient = axios.create({
       baseURL: SDK_API_BASE_URL,
       headers: {
@@ -59,7 +66,7 @@ export class ScallopIndexer {
    * @return Market data.
    */
   public async getMarket(): Promise<Pick<Market, 'pools' | 'collaterals'>> {
-    const response = await this._cache.queryClient.fetchQuery({
+    const response = await this.cache.queryClient.fetchQuery({
       queryKey: ['market'],
       queryFn: async () => {
         return await this._requestClient.get<{
@@ -137,7 +144,7 @@ export class ScallopIndexer {
    * @return Spools data.
    */
   public async getSpools(): Promise<Required<Spools>> {
-    const response = await this._cache.queryClient.fetchQuery({
+    const response = await this.cache.queryClient.fetchQuery({
       queryKey: ['spools'],
       queryFn: async () => {
         return await this._requestClient.get<{
@@ -175,7 +182,7 @@ export class ScallopIndexer {
   public async getBorrowIncentivePools(): Promise<
     Required<BorrowIncentivePools>
   > {
-    const response = await this._cache.queryClient.fetchQuery({
+    const response = await this.cache.queryClient.fetchQuery({
       queryKey: ['borrowIncentivePools'],
       queryFn: async () => {
         return await this._requestClient.get<{
@@ -237,7 +244,7 @@ export class ScallopIndexer {
       supplyValueChangeRatio: number;
     }
   > {
-    const response = await this._cache.queryClient.fetchQuery({
+    const response = await this.cache.queryClient.fetchQuery({
       queryKey: ['totalValueLocked'],
       queryFn: async () => {
         return await this._requestClient.get<

--- a/src/models/scallopUtils.ts
+++ b/src/models/scallopUtils.ts
@@ -2,7 +2,6 @@ import { SUI_TYPE_ARG, normalizeStructTag } from '@mysten/sui.js/utils';
 import { SuiKit } from '@scallop-io/sui-kit';
 import { SuiPriceServiceConnection } from '@pythnetwork/pyth-sui-js';
 import { ScallopAddress } from './scallopAddress';
-import { ScallopQuery } from './scallopQuery';
 import {
   ADDRESSES_ID,
   PROTOCOL_OBJECT_ID,
@@ -19,7 +18,7 @@ import {
   SUPPORT_SCOIN,
   sCoinIds,
 } from '../constants';
-import { queryObligation } from '../queries';
+import { getPythPrice, queryObligation } from '../queries';
 import {
   parseDataFromPythPriceFeed,
   isMarketCoin,
@@ -31,7 +30,6 @@ import { ScallopCache } from './scallopCache';
 import { DEFAULT_CACHE_OPTIONS } from 'src/constants/cache';
 import type {
   ScallopUtilsParams,
-  ScallopInstanceParams,
   SupportCoins,
   SupportAssetCoins,
   SupportMarketCoins,
@@ -41,6 +39,7 @@ import type {
   PriceMap,
   CoinWrappedType,
   SupportSCoin,
+  ScallopUtilsInstanceParams,
 } from '../types';
 import type { SuiAddressArg, SuiTxArg, SuiTxBlock } from '@scallop-io/sui-kit';
 
@@ -60,36 +59,42 @@ export class ScallopUtils {
   public readonly params: ScallopUtilsParams;
   public readonly isTestnet: boolean;
 
-  private _suiKit: SuiKit;
-  private _address: ScallopAddress;
-  private _query: ScallopQuery;
+  public suiKit: SuiKit;
+  public address: ScallopAddress;
+  public cache: ScallopCache;
   private _priceMap: PriceMap = new Map();
-  private _cache: ScallopCache;
 
   public constructor(
     params: ScallopUtilsParams,
-    instance?: ScallopInstanceParams
+    instance?: ScallopUtilsInstanceParams
   ) {
-    this.params = params;
-    this._suiKit = instance?.suiKit ?? new SuiKit(params);
-    this._cache =
-      instance?.cache ?? new ScallopCache(DEFAULT_CACHE_OPTIONS, this._suiKit);
-    this._address =
-      instance?.address ??
-      new ScallopAddress(
-        {
-          id: params?.addressesId || ADDRESSES_ID,
-          network: params?.networkType,
-        },
-        this._cache
-      );
-    this._query =
-      instance?.query ??
-      new ScallopQuery(params, {
-        suiKit: this._suiKit,
-        address: this._address,
-        cache: this._cache,
-      });
+    this.params = {
+      pythEndpoints: params.pythEndpoints ?? PYTH_ENDPOINTS['mainnet'],
+      ...params,
+    };
+    this.suiKit =
+      instance?.suiKit ??
+      instance?.address?.cache._suiKit ??
+      new SuiKit(params);
+
+    if (instance?.address) {
+      this.address = instance.address;
+      this.cache = this.address.cache;
+      this.suiKit = this.address.cache._suiKit;
+    } else {
+      this.cache = new ScallopCache(this.suiKit, DEFAULT_CACHE_OPTIONS);
+      this.address =
+        instance?.address ??
+        new ScallopAddress(
+          {
+            id: params?.addressesId || ADDRESSES_ID,
+            network: params?.networkType,
+          },
+          {
+            cache: this.cache,
+          }
+        );
+    }
     this.isTestnet = params.networkType
       ? params.networkType === 'testnet'
       : false;
@@ -102,14 +107,10 @@ export class ScallopUtils {
    * @param address - ScallopAddress instance.
    */
   public async init(force: boolean = false, address?: ScallopAddress) {
-    if (force || !this._address.getAddresses() || !address?.getAddresses()) {
-      await this._address.read();
+    if (force || !this.address.getAddresses() || !address?.getAddresses()) {
+      await this.address.read();
     } else {
-      this._address = address;
-    }
-
-    if (!this._query.address.getAddresses()) {
-      await this._query.init(force, this._address);
+      this.address = address;
     }
   }
 
@@ -146,7 +147,7 @@ export class ScallopUtils {
   public parseCoinType(coinName: SupportCoins) {
     coinName = isMarketCoin(coinName) ? this.parseCoinName(coinName) : coinName;
     const coinPackageId =
-      this._address.get(`core.coins.${coinName}.id`) ||
+      this.address.get(`core.coins.${coinName}.id`) ||
       coinIds[coinName] ||
       undefined;
     if (!coinPackageId) {
@@ -154,20 +155,20 @@ export class ScallopUtils {
     }
     if (coinName === 'sui')
       return normalizeStructTag(`${coinPackageId}::sui::SUI`);
-    const wormHolePckageIds = [
-      this._address.get('core.coins.usdc.id') ?? wormholeCoinIds.usdc,
-      this._address.get('core.coins.usdt.id') ?? wormholeCoinIds.usdt,
-      this._address.get('core.coins.eth.id') ?? wormholeCoinIds.eth,
-      this._address.get('core.coins.btc.id') ?? wormholeCoinIds.btc,
-      this._address.get('core.coins.sol.id') ?? wormholeCoinIds.sol,
-      this._address.get('core.coins.apt.id') ?? wormholeCoinIds.apt,
+    const wormHolePackageIds = [
+      this.address.get('core.coins.usdc.id') ?? wormholeCoinIds.usdc,
+      this.address.get('core.coins.usdt.id') ?? wormholeCoinIds.usdt,
+      this.address.get('core.coins.eth.id') ?? wormholeCoinIds.eth,
+      this.address.get('core.coins.btc.id') ?? wormholeCoinIds.btc,
+      this.address.get('core.coins.sol.id') ?? wormholeCoinIds.sol,
+      this.address.get('core.coins.apt.id') ?? wormholeCoinIds.apt,
     ];
-    const voloPckageIds = [
-      this._address.get('core.coins.vsui.id') ?? voloCoinIds.vsui,
+    const voloPackageIds = [
+      this.address.get('core.coins.vsui.id') ?? voloCoinIds.vsui,
     ];
-    if (wormHolePckageIds.includes(coinPackageId)) {
+    if (wormHolePackageIds.includes(coinPackageId)) {
       return `${coinPackageId}::coin::COIN`;
-    } else if (voloPckageIds.includes(coinPackageId)) {
+    } else if (voloPackageIds.includes(coinPackageId)) {
       return `${coinPackageId}::cert::CERT`;
     } else {
       return `${coinPackageId}::${coinName}::${coinName.toUpperCase()}`;
@@ -222,7 +223,7 @@ export class ScallopUtils {
    * @returns sCoin treasury id
    */
   public getSCoinTreasury(sCoinName: SupportSCoin) {
-    return this._address.get(`scoin.coins.${sCoinName}.treasury`);
+    return this.address.get(`scoin.coins.${sCoinName}.treasury`);
   }
 
   /**
@@ -234,7 +235,7 @@ export class ScallopUtils {
    */
   public parseMarketCoinType(coinName: SupportCoins) {
     const protocolObjectId =
-      this._address.get('core.object') || PROTOCOL_OBJECT_ID;
+      this.address.get('core.object') || PROTOCOL_OBJECT_ID;
     const coinType = this.parseCoinType(coinName);
     return `${protocolObjectId}::reserve::MarketCoin<${coinType}>`;
   }
@@ -267,27 +268,27 @@ export class ScallopUtils {
 
     const wormHoleCoinTypeMap: Record<string, SupportAssetCoins> = {
       [`${
-        this._address.get('core.coins.usdc.id') ?? wormholeCoinIds.usdc
+        this.address.get('core.coins.usdc.id') ?? wormholeCoinIds.usdc
       }::coin::COIN`]: 'usdc',
       [`${
-        this._address.get('core.coins.usdt.id') ?? wormholeCoinIds.usdt
+        this.address.get('core.coins.usdt.id') ?? wormholeCoinIds.usdt
       }::coin::COIN`]: 'usdt',
       [`${
-        this._address.get('core.coins.eth.id') ?? wormholeCoinIds.eth
+        this.address.get('core.coins.eth.id') ?? wormholeCoinIds.eth
       }::coin::COIN`]: 'eth',
       [`${
-        this._address.get('core.coins.btc.id') ?? wormholeCoinIds.btc
+        this.address.get('core.coins.btc.id') ?? wormholeCoinIds.btc
       }::coin::COIN`]: 'btc',
       [`${
-        this._address.get('core.coins.sol.id') ?? wormholeCoinIds.sol
+        this.address.get('core.coins.sol.id') ?? wormholeCoinIds.sol
       }::coin::COIN`]: 'sol',
       [`${
-        this._address.get('core.coins.apt.id') ?? wormholeCoinIds.apt
+        this.address.get('core.coins.apt.id') ?? wormholeCoinIds.apt
       }::coin::COIN`]: 'apt',
     };
     const voloCoinTypeMap: Record<string, SupportAssetCoins> = {
       [`${
-        this._address.get('core.coins.vsui.id') ?? voloCoinIds.vsui
+        this.address.get('core.coins.vsui.id') ?? voloCoinIds.vsui
       }::cert::CERT`]: 'vsui',
     };
 
@@ -388,8 +389,8 @@ export class ScallopUtils {
     coinType: string = SUI_TYPE_ARG,
     ownerAddress?: string
   ) {
-    ownerAddress = ownerAddress || this._suiKit.currentAddress();
-    const coins = await this._suiKit.suiInteractor.selectCoins(
+    ownerAddress = ownerAddress || this.suiKit.currentAddress();
+    const coins = await this.suiKit.suiInteractor.selectCoins(
       ownerAddress,
       amount,
       coinType
@@ -437,15 +438,15 @@ export class ScallopUtils {
    * @return Asset coin Names.
    */
   public async getObligationCoinNames(obligationId: SuiAddressArg) {
-    const obligation = await queryObligation(this._query, obligationId);
-    const collateralCoinTypes =
-      obligation?.collaterals.map((collateral) => {
-        return `0x${collateral.type.name}`;
-      }) ?? [];
-    const debtCoinTypes =
-      obligation?.debts.map((debt) => {
-        return `0x${debt.type.name}`;
-      }) ?? [];
+    const obligation = await queryObligation(this, obligationId);
+    if (!obligation) return undefined;
+
+    const collateralCoinTypes = obligation.collaterals.map((collateral) => {
+      return `0x${collateral.type.name}`;
+    });
+    const debtCoinTypes = obligation.debts.map((debt) => {
+      return `0x${debt.type.name}`;
+    });
     const obligationCoinTypes = [
       ...new Set([...collateralCoinTypes, ...debtCoinTypes]),
     ];
@@ -507,7 +508,7 @@ export class ScallopUtils {
       for (const endpoint of endpoints) {
         const priceIds = Array.from(failedRequests.values()).reduce(
           (acc, coinName) => {
-            const priceId = this._address.get(
+            const priceId = this.address.get(
               `core.coins.${coinName}.oracle.pyth.feed`
             );
             acc[coinName] = priceId;
@@ -520,14 +521,14 @@ export class ScallopUtils {
           Object.entries(priceIds).map(async ([coinName, priceId]) => {
             const pythConnection = new SuiPriceServiceConnection(endpoint);
             try {
-              const feed = await this._cache.queryClient.fetchQuery({
+              const feed = await this.address.cache.queryClient.fetchQuery({
                 queryKey: [priceId],
                 queryFn: async () => {
                   return await pythConnection.getLatestPriceFeeds([priceId]);
                 },
               });
               if (feed) {
-                const data = parseDataFromPythPriceFeed(feed[0], this._address);
+                const data = parseDataFromPythPriceFeed(feed[0], this.address);
                 this._priceMap.set(coinName as SupportAssetCoins, {
                   price: data.price,
                   publishTime: data.publishTime,
@@ -548,7 +549,7 @@ export class ScallopUtils {
       if (failedRequests.size > 0) {
         await Promise.allSettled(
           Array.from(failedRequests.values()).map(async (coinName) => {
-            const price = await this._query.getPriceFromPyth(coinName);
+            const price = await getPythPrice(this, coinName);
             this._priceMap.set(coinName, {
               price: price,
               publishTime: Date.now(),

--- a/src/queries/borrowIncentiveQuery.ts
+++ b/src/queries/borrowIncentiveQuery.ts
@@ -8,7 +8,7 @@ import {
   parseOriginBorrowIncentiveAccountData,
   calculateBorrowIncentivePoolPointData,
 } from '../utils';
-import type { ScallopQuery } from '../models';
+import type { ScallopAddress, ScallopQuery, ScallopUtils } from '../models';
 import type {
   BorrowIncentivePoolsQueryInterface,
   BorrowIncentivePools,
@@ -163,24 +163,27 @@ export const queryBorrowIncentivePools = async (
  * @return Borrow incentive accounts data.
  */
 export const queryBorrowIncentiveAccounts = async (
-  query: ScallopQuery,
+  {
+    utils,
+  }: {
+    utils: ScallopUtils;
+  },
   obligationId: string,
   borrowIncentiveCoinNames?: SupportBorrowIncentiveCoins[]
 ) => {
   borrowIncentiveCoinNames = borrowIncentiveCoinNames || [
     ...SUPPORT_BORROW_INCENTIVE_POOLS,
   ];
-  const queryPkgId = query.address.get('borrowIncentive.query');
-  const incentiveAccountsId = query.address.get(
+  const queryPkgId = utils.address.get('borrowIncentive.query');
+  const incentiveAccountsId = utils.address.get(
     'borrowIncentive.incentiveAccounts'
   );
   const queryTarget = `${queryPkgId}::incentive_account_query::incentive_account_data`;
   const args = [incentiveAccountsId, obligationId];
 
-  const queryResult = await query.cache.queryInspectTxn({ queryTarget, args });
-  const borrowIncentiveAccountsQueryData = queryResult?.events[0].parsedJson as
-    | BorrowIncentiveAccountsQueryInterface
-    | undefined;
+  const queryResult = await utils.cache.queryInspectTxn({ queryTarget, args });
+  const borrowIncentiveAccountsQueryData = queryResult?.events[0]
+    .parsedJson as BorrowIncentiveAccountsQueryInterface;
 
   const borrowIncentiveAccounts: BorrowIncentiveAccounts = Object.values(
     borrowIncentiveAccountsQueryData?.pool_records ?? []
@@ -189,7 +192,7 @@ export const queryBorrowIncentiveAccounts = async (
       parseOriginBorrowIncentiveAccountData(accountData);
     const poolType = parsedBorrowIncentiveAccount.poolType;
     const coinName =
-      query.utils.parseCoinNameFromType<SupportBorrowIncentiveCoins>(poolType);
+      utils.parseCoinNameFromType<SupportBorrowIncentiveCoins>(poolType);
 
     if (
       borrowIncentiveCoinNames &&
@@ -211,15 +214,19 @@ export const queryBorrowIncentiveAccounts = async (
  * @returns
  */
 export const getBindedObligationId = async (
-  query: ScallopQuery,
+  {
+    address,
+  }: {
+    address: ScallopAddress;
+  },
   veScaKeyId: string
 ): Promise<string | null> => {
-  const borrowIncentiveObjectId = query.address.get('borrowIncentive.object');
-  const incentivePoolsId = query.address.get('borrowIncentive.incentivePools');
-  const veScaObjId = query.address.get('vesca.object');
+  const borrowIncentiveObjectId = address.get('borrowIncentive.object');
+  const incentivePoolsId = address.get('borrowIncentive.incentivePools');
+  const veScaObjId = address.get('vesca.object');
 
   // get incentive pools
-  const incentivePoolsResponse = await query.cache.queryGetObject(
+  const incentivePoolsResponse = await address.cache.queryGetObject(
     incentivePoolsId,
     {
       showContent: true,
@@ -234,13 +241,15 @@ export const getBindedObligationId = async (
 
   // check if veSca is inside the bind table
   const keyType = `${borrowIncentiveObjectId}::typed_id::TypedID<${veScaObjId}::ve_sca::VeScaKey>`;
-  const veScaBindTableResponse = await query.cache.queryGetDynamicFieldObject({
-    parentId: veScaBindTableId,
-    name: {
-      type: keyType,
-      value: veScaKeyId,
-    },
-  });
+  const veScaBindTableResponse = await address.cache.queryGetDynamicFieldObject(
+    {
+      parentId: veScaBindTableId,
+      name: {
+        type: keyType,
+        value: veScaKeyId,
+      },
+    }
+  );
 
   if (veScaBindTableResponse?.data?.content?.dataType !== 'moveObject')
     return null;
@@ -253,17 +262,19 @@ export const getBindedObligationId = async (
 };
 
 export const getBindedVeScaKey = async (
-  query: ScallopQuery,
+  {
+    address,
+  }: {
+    address: ScallopAddress;
+  },
   obliationId: string
 ): Promise<string | null> => {
-  const borrowIncentiveObjectId = query.address.get('borrowIncentive.object');
-  const incentiveAccountsId = query.address.get(
-    'borrowIncentive.incentiveAccounts'
-  );
-  const corePkg = query.address.get('core.object');
+  const borrowIncentiveObjectId = address.get('borrowIncentive.object');
+  const incentiveAccountsId = address.get('borrowIncentive.incentiveAccounts');
+  const corePkg = address.get('core.object');
 
   // get IncentiveAccounts object
-  const incentiveAccountsObject = await query.cache.queryGetObject(
+  const incentiveAccountsObject = await address.cache.queryGetObject(
     incentiveAccountsId,
     {
       showContent: true,
@@ -276,7 +287,7 @@ export const getBindedVeScaKey = async (
   ).accounts.fields.id.id;
 
   // Search in the table
-  const bindedIncentiveAcc = await query.cache.queryGetDynamicFieldObject({
+  const bindedIncentiveAcc = await address.cache.queryGetDynamicFieldObject({
     parentId: incentiveAccountsTableId,
     name: {
       type: `${borrowIncentiveObjectId}::typed_id::TypedID<${corePkg}::obligation::Obligation>`,

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -38,11 +38,10 @@ import type {
  */
 export const getLendings = async (
   query: ScallopQuery,
-  poolCoinNames?: SupportPoolCoins[],
+  poolCoinNames: SupportPoolCoins[] = [...SUPPORT_POOLS],
   ownerAddress?: string,
   indexer: boolean = false
 ) => {
-  poolCoinNames = poolCoinNames || [...SUPPORT_POOLS];
   const marketCoinNames = poolCoinNames.map((poolCoinName) =>
     query.utils.parseMarketCoinName(poolCoinName)
   );

--- a/src/queries/referralQuery.ts
+++ b/src/queries/referralQuery.ts
@@ -1,4 +1,4 @@
-import { ScallopQuery } from 'src/models';
+import { ScallopAddress } from 'src/models';
 
 /**
  * Query the veScaKeyId from the referral bindings table using the borrower address
@@ -6,12 +6,12 @@ import { ScallopQuery } from 'src/models';
  * @returns
  */
 export const queryVeScaKeyIdFromReferralBindings = async (
-  query: ScallopQuery,
+  address: ScallopAddress,
   refereeAddress: string
 ): Promise<string | null> => {
-  const referralBindingTableId = query.address.get('referral.bindingTableId');
+  const referralBindingTableId = address.get('referral.bindingTableId');
 
-  const referralBindResponse = await query.cache.queryGetDynamicFieldObject({
+  const referralBindResponse = await address.cache.queryGetDynamicFieldObject({
     parentId: referralBindingTableId,
     name: {
       type: 'address',

--- a/src/queries/spoolQuery.ts
+++ b/src/queries/spoolQuery.ts
@@ -8,7 +8,7 @@ import {
   isMarketCoin,
 } from '../utils';
 import type { SuiObjectResponse } from '@mysten/sui.js/client';
-import type { ScallopQuery } from '../models';
+import type { ScallopQuery, ScallopUtils } from '../models';
 import type {
   MarketPool,
   Spools,
@@ -231,18 +231,22 @@ export const getSpool = async (
  * @return Stake accounts.
  */
 export const getStakeAccounts = async (
-  query: ScallopQuery,
+  {
+    utils,
+  }: {
+    utils: ScallopUtils;
+  },
   ownerAddress?: string
 ) => {
-  const owner = ownerAddress || query.suiKit.currentAddress();
-  const spoolObjectId = query.address.get('spool.object');
+  const owner = ownerAddress || utils.suiKit.currentAddress();
+  const spoolObjectId = utils.address.get('spool.object');
   const stakeAccountType = `${spoolObjectId}::spool_account::SpoolAccount`;
   const stakeObjectsResponse: SuiObjectResponse[] = [];
   let hasNextPage = false;
   let nextCursor: string | null | undefined = null;
   do {
     const paginatedStakeObjectsResponse =
-      await query.cache.queryGetOwnedObjects({
+      await utils.cache.queryGetOwnedObjects({
         owner,
         filter: { StructType: stakeAccountType },
         options: {
@@ -281,8 +285,8 @@ export const getStakeAccounts = async (
     Object.keys(stakeAccounts).reduce(
       (types, stakeMarketCoinName) => {
         const stakeCoinName =
-          query.utils.parseCoinName<SupportStakeCoins>(stakeMarketCoinName);
-        const marketCoinType = query.utils.parseMarketCoinType(stakeCoinName);
+          utils.parseCoinName<SupportStakeCoins>(stakeMarketCoinName);
+        const marketCoinType = utils.parseMarketCoinType(stakeCoinName);
 
         types[
           stakeMarketCoinName as SupportStakeMarketCoins
@@ -295,7 +299,7 @@ export const getStakeAccounts = async (
   const stakeObjectIds: string[] = stakeObjectsResponse
     .map((ref: any) => ref?.data?.objectId)
     .filter((id: any) => id !== undefined);
-  const stakeObjects = await query.cache.queryGetObjects(stakeObjectIds);
+  const stakeObjects = await utils.cache.queryGetObjects(stakeObjectIds);
   for (const stakeObject of stakeObjects) {
     const id = stakeObject.objectId;
     const type = stakeObject.type!;
@@ -413,12 +417,16 @@ export const getStakeAccounts = async (
  * @return Stake pool data.
  */
 export const getStakePool = async (
-  query: ScallopQuery,
+  {
+    utils,
+  }: {
+    utils: ScallopUtils;
+  },
   marketCoinName: SupportStakeMarketCoins
 ) => {
-  const poolId = query.address.get(`spool.pools.${marketCoinName}.id`);
+  const poolId = utils.address.get(`spool.pools.${marketCoinName}.id`);
   let stakePool: StakePool | undefined = undefined;
-  const stakePoolObjectResponse = await query.cache.queryGetObject(poolId, {
+  const stakePoolObjectResponse = await utils.cache.queryGetObject(poolId, {
     showContent: true,
     showType: true,
   });
@@ -469,14 +477,18 @@ export const getStakePool = async (
  * @return Stake reward pool.
  */
 export const getStakeRewardPool = async (
-  query: ScallopQuery,
+  {
+    utils,
+  }: {
+    utils: ScallopUtils;
+  },
   marketCoinName: SupportStakeMarketCoins
 ) => {
-  const poolId = query.address.get(
+  const poolId = utils.address.get(
     `spool.pools.${marketCoinName}.rewardPoolId`
   );
   let stakeRewardPool: StakeRewardPool | undefined = undefined;
-  const stakeRewardPoolObjectResponse = await query.cache.queryGetObject(
+  const stakeRewardPoolObjectResponse = await utils.cache.queryGetObject(
     poolId,
     {
       showContent: true,

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -6,6 +6,7 @@ import type {
   ScallopQuery,
   ScallopUtils,
   ScallopBuilder,
+  ScallopIndexer,
 } from '../models';
 import { ScallopCache } from 'src/models/scallopCache';
 
@@ -13,13 +14,35 @@ export type ScallopClientFnReturnType<T extends boolean> = T extends true
   ? SuiTransactionBlockResponse
   : TransactionBlock;
 
-export type ScallopInstanceParams = {
+export type ScallopBaseInstanceParams = {
   suiKit?: SuiKit;
+};
+
+export type ScallopCacheInstanceParams = ScallopBaseInstanceParams;
+
+export type ScallopAddressInstanceParams = ScallopBaseInstanceParams & {
+  cache?: ScallopCache;
+};
+
+export type ScallopIndexerInstanceParams = {
+  cache?: ScallopCache;
+};
+
+export type ScallopUtilsInstanceParams = ScallopBaseInstanceParams & {
   address?: ScallopAddress;
-  query?: ScallopQuery;
+};
+
+export type ScallopQueryInstanceParams = ScallopBaseInstanceParams & {
   utils?: ScallopUtils;
+  indexer?: ScallopIndexer;
+};
+
+export type ScallopBuilderInstanceParams = ScallopBaseInstanceParams & {
+  query?: ScallopQuery;
+};
+
+export type ScallopClientInstanceParams = ScallopBaseInstanceParams & {
   builder?: ScallopBuilder;
-  cache: ScallopCache;
 };
 
 export type ScallopAddressParams = {
@@ -30,20 +53,16 @@ export type ScallopAddressParams = {
 
 export type ScallopParams = {
   addressesId?: string;
+  walletAddress?: string;
 } & SuiKitParams;
 
-export type ScallopClientParams = ScallopParams & {
-  walletAddress?: string;
-};
+export type ScallopClientParams = ScallopParams;
 
 export type ScallopBuilderParams = ScallopParams & {
-  walletAddress?: string;
   pythEndpoints?: string[];
 };
 
-export type ScallopQueryParams = ScallopParams & {
-  walletAddress?: string;
-};
+export type ScallopQueryParams = ScallopParams;
 
 export type ScallopUtilsParams = ScallopParams & {
   pythEndpoints?: string[];

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -310,7 +310,7 @@ describe('Test VeSca Query', async () => {
   const sender = scallopQuery.suiKit.currentAddress();
   console.info(`Your Wallet: ${sender}`);
 
-  const veScaKeys = await getVescaKeys(scallopQuery, sender);
+  const veScaKeys = await getVescaKeys(scallopQuery.utils, sender);
   let obligationId: string | undefined;
   if (veScaKeys.length === 0)
     throw new Error(`No VeSca keys found in ${sender}`);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -194,13 +194,10 @@ describe('Test Scallop Utils', async () => {
   });
 
   it('Should get coin object ids within the selected coin amount range', async () => {
-    const suiCoinType = await scallopUtils.parseCoinType('sui');
-    const suiMarketCoinType = await scallopUtils.parseMarketCoinType('ssui');
-    const suiCoinObjectIds = await scallopUtils.selectCoins(
-      1000000000,
-      suiCoinType
-    );
-    const suiMarketCoinObjectIds = await scallopUtils.selectCoins(
+    const suiCoinType = scallopUtils.parseCoinType('sui');
+    const suiMarketCoinType = scallopUtils.parseSCoinType('ssui');
+    const suiCoinObjectIds = scallopUtils.selectCoins(1e7, suiCoinType);
+    const suiMarketCoinObjectIds = scallopUtils.selectCoins(
       1,
       suiMarketCoinType
     );


### PR DESCRIPTION
### CHANGES
In the old structure, there was a circular dependency between ScallopUtils and ScallopQuery, where ScallopUtils imported from ScallopQuery and vice versa. This update refactors the structure to further separate the class hierarchy and eliminate the circular dependency

The new class hierarchy, from top to bottom, is as follows:
- Scallop Client
- Scallop Builder
- Scallop Query
- Scallop Utils & ScallopIndexer
- Scallop Address
- Scallop Cache
