### PR TITLE
refactor: move all indexer arg into object param

### DIFF
--- a/src/constants/tokenBucket.ts
+++ b/src/constants/tokenBucket.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_TOKENS_PER_INTERVAL = 50;
-export const DEFAULT_INTERVAL_IN_MS = 300;
+export const DEFAULT_INTERVAL_IN_MS = 100;

--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -191,11 +191,11 @@ export class ScallopQuery {
    * @param indexer - Whether to use indexer.
    * @return Market data.
    */
-  public async queryMarket(
-    indexer: boolean = false,
-    args?: { coinPrices: CoinPrices }
-  ) {
-    return await queryMarket(this, indexer, args?.coinPrices);
+  public async queryMarket(args?: {
+    coinPrices?: CoinPrices;
+    indexer?: boolean;
+  }) {
+    return await queryMarket(this, args?.indexer, args?.coinPrices);
   }
 
   /**
@@ -211,12 +211,17 @@ export class ScallopQuery {
    */
   public async getMarketPools(
     poolCoinNames?: SupportPoolCoins[],
-    indexer: boolean = false,
     args?: {
       coinPrices?: CoinPrices;
+      indexer?: boolean;
     }
   ) {
-    return await getMarketPools(this, poolCoinNames, indexer, args?.coinPrices);
+    return await getMarketPools(
+      this,
+      poolCoinNames,
+      args?.indexer,
+      args?.coinPrices
+    );
   }
 
   /**
@@ -228,16 +233,16 @@ export class ScallopQuery {
    */
   public async getMarketPool(
     poolCoinName: SupportPoolCoins,
-    indexer: boolean = false,
     args?: {
       marketObject?: SuiObjectData | null;
       coinPrice?: number;
+      indexer?: boolean;
     }
   ) {
     return await getMarketPool(
       this,
       poolCoinName,
-      indexer,
+      args?.indexer,
       args?.marketObject,
       args?.coinPrice
     );
@@ -256,9 +261,9 @@ export class ScallopQuery {
    */
   public async getMarketCollaterals(
     collateralCoinNames?: SupportCollateralCoins[],
-    indexer: boolean = false
+    args?: { indexer?: boolean }
   ) {
-    return await getMarketCollaterals(this, collateralCoinNames, indexer);
+    return await getMarketCollaterals(this, collateralCoinNames, args?.indexer);
   }
 
   /**
@@ -270,9 +275,9 @@ export class ScallopQuery {
    */
   public async getMarketCollateral(
     collateralCoinName: SupportCollateralCoins,
-    indexer: boolean = false
+    args?: { indexer?: boolean }
   ) {
-    return await getMarketCollateral(this, collateralCoinName, indexer);
+    return await getMarketCollateral(this, collateralCoinName, args?.indexer);
   }
 
   /**
@@ -382,16 +387,16 @@ export class ScallopQuery {
    */
   public async getSpools(
     stakeMarketCoinNames?: SupportStakeMarketCoins[],
-    indexer: boolean = false,
     args?: {
       marketPools?: MarketPools;
       coinPrices?: CoinPrices;
+      indexer?: boolean;
     }
   ) {
     return await getSpools(
       this,
       stakeMarketCoinNames,
-      indexer,
+      args?.indexer,
       args?.marketPools,
       args?.coinPrices
     );
@@ -406,13 +411,16 @@ export class ScallopQuery {
    */
   public async getSpool(
     stakeMarketCoinName: SupportStakeMarketCoins,
-    indexer: boolean = false,
-    args?: { marketPool?: MarketPool; coinPrices?: CoinPrices }
+    args?: {
+      marketPool?: MarketPool;
+      coinPrices?: CoinPrices;
+      indexer?: boolean;
+    }
   ) {
     return await getSpool(
       this,
       stakeMarketCoinName,
-      indexer,
+      args?.indexer,
       args?.marketPool,
       args?.coinPrices
     );
@@ -536,13 +544,12 @@ export class ScallopQuery {
    */
   public async getBorrowIncentivePools(
     coinNames?: SupportBorrowIncentiveCoins[],
-    indexer: boolean = false,
-    args?: { coinPrices: CoinPrices }
+    args?: { coinPrices: CoinPrices; indexer?: boolean }
   ) {
     return await getBorrowIncentivePools(
       this,
       coinNames,
-      indexer,
+      args?.indexer,
       args?.coinPrices
     );
   }
@@ -572,9 +579,9 @@ export class ScallopQuery {
   public async getLendings(
     poolCoinNames?: SupportPoolCoins[],
     ownerAddress: string = this.walletAddress,
-    indexer: boolean = false
+    args?: { indexer?: boolean }
   ) {
-    return await getLendings(this, poolCoinNames, ownerAddress, indexer);
+    return await getLendings(this, poolCoinNames, ownerAddress, args?.indexer);
   }
 
   /**
@@ -588,9 +595,9 @@ export class ScallopQuery {
   public async getLending(
     poolCoinName: SupportPoolCoins,
     ownerAddress: string = this.walletAddress,
-    indexer: boolean = false
+    args?: { indexer?: boolean }
   ) {
-    return await getLending(this, poolCoinName, ownerAddress, indexer);
+    return await getLending(this, poolCoinName, ownerAddress, args?.indexer);
   }
 
   /**
@@ -605,9 +612,9 @@ export class ScallopQuery {
    */
   public async getObligationAccounts(
     ownerAddress: string = this.walletAddress,
-    indexer: boolean = false
+    args?: { indexer: boolean }
   ) {
-    return await getObligationAccounts(this, ownerAddress, indexer);
+    return await getObligationAccounts(this, ownerAddress, args?.indexer);
   }
 
   /**
@@ -624,13 +631,13 @@ export class ScallopQuery {
   public async getObligationAccount(
     obligationId: string,
     ownerAddress: string = this.walletAddress,
-    indexer: boolean = false
+    args?: { indexer?: boolean }
   ) {
     return await getObligationAccount(
       this,
       obligationId,
       ownerAddress,
-      indexer
+      args?.indexer
     );
   }
 
@@ -643,8 +650,8 @@ export class ScallopQuery {
    *
    * @return Total value locked.
    */
-  public async getTvl(indexer: boolean = false) {
-    return await getTotalValueLocked(this, indexer);
+  public async getTvl(args?: { indexer?: boolean }) {
+    return await getTotalValueLocked(this, args?.indexer);
   }
 
   /**

--- a/src/queries/coreQuery.ts
+++ b/src/queries/coreQuery.ts
@@ -305,222 +305,217 @@ export const getMarketPool = async (
   marketObject?: SuiObjectData | null,
   coinPrice?: number
 ): Promise<MarketPool | undefined> => {
-  try {
-    coinPrice =
-      coinPrice ||
-      (await query.utils.getCoinPrices([poolCoinName]))?.[poolCoinName];
+  coinPrice =
+    coinPrice ||
+    (await query.utils.getCoinPrices([poolCoinName]))?.[poolCoinName];
 
-    if (indexer) {
-      const marketPoolIndexer = await query.indexer.getMarketPool(poolCoinName);
-      if (!marketPoolIndexer) {
-        return undefined;
-      }
-      marketPoolIndexer.coinPrice = coinPrice ?? marketPoolIndexer.coinPrice;
-      marketPoolIndexer.coinWrappedType = query.utils.getCoinWrappedType(
-        marketPoolIndexer.coinName
-      );
-
-      return marketPoolIndexer;
+  if (indexer) {
+    const marketPoolIndexer = await query.indexer.getMarketPool(poolCoinName);
+    if (!marketPoolIndexer) {
+      return undefined;
     }
-
-    const marketId = query.address.get('core.market');
-    marketObject =
-      marketObject ||
-      (
-        await query.cache.queryGetObject(marketId, {
-          showContent: true,
-        })
-      )?.data;
-
-    if (!(marketObject && marketObject.content?.dataType === 'moveObject'))
-      throw new Error(`Failed to fetch marketObject`);
-
-    const fields = marketObject.content.fields as any;
-    const coinType = query.utils.parseCoinType(poolCoinName);
-    // Get balance sheet.
-    const balanceSheetParentId =
-      fields.vault.fields.balance_sheets.fields.table.fields.id.id;
-    const balanceSheetDynamicFieldObjectResponse =
-      await query.cache.queryGetDynamicFieldObject({
-        parentId: balanceSheetParentId,
-        name: {
-          type: '0x1::type_name::TypeName',
-          value: {
-            name: coinType.substring(2),
-          },
-        },
-      });
-
-    const balanceSheetDynamicFieldObject =
-      balanceSheetDynamicFieldObjectResponse?.data;
-
-    if (
-      !(
-        balanceSheetDynamicFieldObject &&
-        balanceSheetDynamicFieldObject.content &&
-        'fields' in balanceSheetDynamicFieldObject.content
-      )
-    )
-      throw new Error(
-        `Failed to fetch balanceSheetDynamicFieldObject for ${poolCoinName}: ${balanceSheetDynamicFieldObjectResponse?.error?.code.toString()}`
-      );
-    const balanceSheet: BalanceSheet = (
-      balanceSheetDynamicFieldObject.content.fields as any
-    ).value.fields;
-
-    // Get borrow index.
-    const borrowIndexParentId =
-      fields.borrow_dynamics.fields.table.fields.id.id;
-    const borrowIndexDynamicFieldObjectResponse =
-      await query.cache.queryGetDynamicFieldObject({
-        parentId: borrowIndexParentId,
-        name: {
-          type: '0x1::type_name::TypeName',
-          value: {
-            name: coinType.substring(2),
-          },
-        },
-      });
-
-    const borrowIndexDynamicFieldObject =
-      borrowIndexDynamicFieldObjectResponse?.data;
-    if (
-      !(
-        borrowIndexDynamicFieldObject &&
-        borrowIndexDynamicFieldObject.content &&
-        'fields' in borrowIndexDynamicFieldObject.content
-      )
-    )
-      throw new Error(
-        `Failed to fetch borrowIndexDynamicFieldObject for ${poolCoinName}`
-      );
-    const borrowIndex: BorrowIndex = (
-      borrowIndexDynamicFieldObject.content.fields as any
-    ).value.fields;
-
-    // Get interest models.
-    const interestModelParentId =
-      fields.interest_models.fields.table.fields.id.id;
-    const interestModelDynamicFieldObjectResponse =
-      await query.cache.queryGetDynamicFieldObject({
-        parentId: interestModelParentId,
-        name: {
-          type: '0x1::type_name::TypeName',
-          value: {
-            name: coinType.substring(2),
-          },
-        },
-      });
-
-    const interestModelDynamicFieldObject =
-      interestModelDynamicFieldObjectResponse?.data;
-    if (
-      !(
-        interestModelDynamicFieldObject &&
-        interestModelDynamicFieldObject.content &&
-        'fields' in interestModelDynamicFieldObject.content
-      )
-    )
-      throw new Error(
-        `Failed to fetch interestModelDynamicFieldObject for ${poolCoinName}: ${interestModelDynamicFieldObject}`
-      );
-    const interestModel: InterestModel = (
-      interestModelDynamicFieldObject.content.fields as any
-    ).value.fields;
-
-    // Get borrow fee.
-    const getBorrowFee = async () => {
-      const borrowFeeDynamicFieldObjectResponse =
-        await query.cache.queryGetDynamicFieldObject({
-          parentId: marketId,
-          name: {
-            type: `${BORROW_FEE_PROTOCOL_ID}::market_dynamic_keys::BorrowFeeKey`,
-            value: {
-              type: {
-                name: coinType.substring(2),
-              },
-            },
-          },
-        });
-
-      const borrowFeeDynamicFieldObject =
-        borrowFeeDynamicFieldObjectResponse?.data;
-      if (
-        !(
-          borrowFeeDynamicFieldObject &&
-          borrowFeeDynamicFieldObject.content &&
-          'fields' in borrowFeeDynamicFieldObject.content
-        )
-      )
-        return { value: '0' };
-      return (borrowFeeDynamicFieldObject.content.fields as any).value.fields;
-    };
-
-    const parsedMarketPoolData = parseOriginMarketPoolData({
-      type: interestModel.type.fields,
-      maxBorrowRate: interestModel.max_borrow_rate.fields,
-      interestRate: borrowIndex.interest_rate.fields,
-      interestRateScale: borrowIndex.interest_rate_scale,
-      borrowIndex: borrowIndex.borrow_index,
-      lastUpdated: borrowIndex.last_updated,
-      cash: balanceSheet.cash,
-      debt: balanceSheet.debt,
-      marketCoinSupply: balanceSheet.market_coin_supply,
-      reserve: balanceSheet.revenue,
-      reserveFactor: interestModel.revenue_factor.fields,
-      borrowWeight: interestModel.borrow_weight.fields,
-      borrowFeeRate: await getBorrowFee(),
-      baseBorrowRatePerSec: interestModel.base_borrow_rate_per_sec.fields,
-      borrowRateOnHighKink: interestModel.borrow_rate_on_high_kink.fields,
-      borrowRateOnMidKink: interestModel.borrow_rate_on_mid_kink.fields,
-      highKink: interestModel.high_kink.fields,
-      midKink: interestModel.mid_kink.fields,
-      minBorrowAmount: interestModel.min_borrow_amount,
-    });
-
-    const calculatedMarketPoolData = calculateMarketPoolData(
-      query.utils,
-      parsedMarketPoolData
+    marketPoolIndexer.coinPrice = coinPrice ?? marketPoolIndexer.coinPrice;
+    marketPoolIndexer.coinWrappedType = query.utils.getCoinWrappedType(
+      marketPoolIndexer.coinName
     );
 
-    const coinDecimal = query.utils.getCoinDecimal(poolCoinName);
-    const maxSupplyCoin = BigNumber(
-      (await getSupplyLimit(query.utils, poolCoinName)) ?? '0'
-    )
-      .shiftedBy(-coinDecimal)
-      .toNumber();
-    const maxBorrowCoin = BigNumber(
-      (await getBorrowLimit(query.utils, poolCoinName)) ?? '0'
-    )
-      .shiftedBy(-coinDecimal)
-      .toNumber();
-
-    return {
-      coinName: poolCoinName,
-      symbol: query.utils.parseSymbol(poolCoinName),
-      coinType: query.utils.parseCoinType(poolCoinName),
-      marketCoinType: query.utils.parseMarketCoinType(poolCoinName),
-      sCoinType: query.utils.parseSCoinType(
-        query.utils.parseMarketCoinName(poolCoinName)
-      ),
-      coinWrappedType: query.utils.getCoinWrappedType(poolCoinName),
-      coinDecimal,
-      coinPrice: coinPrice ?? 0,
-      highKink: parsedMarketPoolData.highKink,
-      midKink: parsedMarketPoolData.midKink,
-      reserveFactor: parsedMarketPoolData.reserveFactor,
-      borrowWeight: parsedMarketPoolData.borrowWeight,
-      borrowFee: parsedMarketPoolData.borrowFee,
-      marketCoinSupplyAmount: parsedMarketPoolData.marketCoinSupplyAmount,
-      minBorrowAmount: parsedMarketPoolData.minBorrowAmount,
-      maxSupplyCoin,
-      maxBorrowCoin,
-      isIsolated: await isIsolatedAsset(query.utils, poolCoinName),
-      ...calculatedMarketPoolData,
-    };
-  } catch (e: any) {
-    console.error(e.message);
+    return marketPoolIndexer;
   }
+
+  const marketId = query.address.get('core.market');
+  marketObject =
+    marketObject ||
+    (
+      await query.cache.queryGetObject(marketId, {
+        showContent: true,
+      })
+    )?.data;
+
+  if (!(marketObject && marketObject.content?.dataType === 'moveObject'))
+    throw new Error(`Failed to fetch marketObject`);
+
+  const fields = marketObject.content.fields as any;
+  const coinType = query.utils.parseCoinType(poolCoinName);
+  // Get balance sheet.
+  const balanceSheetParentId =
+    fields.vault.fields.balance_sheets.fields.table.fields.id.id;
+  const balanceSheetDynamicFieldObjectResponse =
+    await query.cache.queryGetDynamicFieldObject({
+      parentId: balanceSheetParentId,
+      name: {
+        type: '0x1::type_name::TypeName',
+        value: {
+          name: coinType.substring(2),
+        },
+      },
+    });
+
+  const balanceSheetDynamicFieldObject =
+    balanceSheetDynamicFieldObjectResponse?.data;
+
+  if (
+    !(
+      balanceSheetDynamicFieldObject &&
+      balanceSheetDynamicFieldObject.content &&
+      'fields' in balanceSheetDynamicFieldObject.content
+    )
+  )
+    throw new Error(
+      `Failed to fetch balanceSheetDynamicFieldObject for ${poolCoinName}: ${balanceSheetDynamicFieldObjectResponse?.error?.code.toString()}`
+    );
+  const balanceSheet: BalanceSheet = (
+    balanceSheetDynamicFieldObject.content.fields as any
+  ).value.fields;
+
+  // Get borrow index.
+  const borrowIndexParentId = fields.borrow_dynamics.fields.table.fields.id.id;
+  const borrowIndexDynamicFieldObjectResponse =
+    await query.cache.queryGetDynamicFieldObject({
+      parentId: borrowIndexParentId,
+      name: {
+        type: '0x1::type_name::TypeName',
+        value: {
+          name: coinType.substring(2),
+        },
+      },
+    });
+
+  const borrowIndexDynamicFieldObject =
+    borrowIndexDynamicFieldObjectResponse?.data;
+  if (
+    !(
+      borrowIndexDynamicFieldObject &&
+      borrowIndexDynamicFieldObject.content &&
+      'fields' in borrowIndexDynamicFieldObject.content
+    )
+  )
+    throw new Error(
+      `Failed to fetch borrowIndexDynamicFieldObject for ${poolCoinName}`
+    );
+  const borrowIndex: BorrowIndex = (
+    borrowIndexDynamicFieldObject.content.fields as any
+  ).value.fields;
+
+  // Get interest models.
+  const interestModelParentId =
+    fields.interest_models.fields.table.fields.id.id;
+  const interestModelDynamicFieldObjectResponse =
+    await query.cache.queryGetDynamicFieldObject({
+      parentId: interestModelParentId,
+      name: {
+        type: '0x1::type_name::TypeName',
+        value: {
+          name: coinType.substring(2),
+        },
+      },
+    });
+
+  const interestModelDynamicFieldObject =
+    interestModelDynamicFieldObjectResponse?.data;
+  if (
+    !(
+      interestModelDynamicFieldObject &&
+      interestModelDynamicFieldObject.content &&
+      'fields' in interestModelDynamicFieldObject.content
+    )
+  )
+    throw new Error(
+      `Failed to fetch interestModelDynamicFieldObject for ${poolCoinName}: ${interestModelDynamicFieldObject}`
+    );
+  const interestModel: InterestModel = (
+    interestModelDynamicFieldObject.content.fields as any
+  ).value.fields;
+
+  // Get borrow fee.
+  const getBorrowFee = async () => {
+    const borrowFeeDynamicFieldObjectResponse =
+      await query.cache.queryGetDynamicFieldObject({
+        parentId: marketId,
+        name: {
+          type: `${BORROW_FEE_PROTOCOL_ID}::market_dynamic_keys::BorrowFeeKey`,
+          value: {
+            type: {
+              name: coinType.substring(2),
+            },
+          },
+        },
+      });
+
+    const borrowFeeDynamicFieldObject =
+      borrowFeeDynamicFieldObjectResponse?.data;
+    if (
+      !(
+        borrowFeeDynamicFieldObject &&
+        borrowFeeDynamicFieldObject.content &&
+        'fields' in borrowFeeDynamicFieldObject.content
+      )
+    )
+      return { value: '0' };
+    return (borrowFeeDynamicFieldObject.content.fields as any).value.fields;
+  };
+
+  const parsedMarketPoolData = parseOriginMarketPoolData({
+    type: interestModel.type.fields,
+    maxBorrowRate: interestModel.max_borrow_rate.fields,
+    interestRate: borrowIndex.interest_rate.fields,
+    interestRateScale: borrowIndex.interest_rate_scale,
+    borrowIndex: borrowIndex.borrow_index,
+    lastUpdated: borrowIndex.last_updated,
+    cash: balanceSheet.cash,
+    debt: balanceSheet.debt,
+    marketCoinSupply: balanceSheet.market_coin_supply,
+    reserve: balanceSheet.revenue,
+    reserveFactor: interestModel.revenue_factor.fields,
+    borrowWeight: interestModel.borrow_weight.fields,
+    borrowFeeRate: await getBorrowFee(),
+    baseBorrowRatePerSec: interestModel.base_borrow_rate_per_sec.fields,
+    borrowRateOnHighKink: interestModel.borrow_rate_on_high_kink.fields,
+    borrowRateOnMidKink: interestModel.borrow_rate_on_mid_kink.fields,
+    highKink: interestModel.high_kink.fields,
+    midKink: interestModel.mid_kink.fields,
+    minBorrowAmount: interestModel.min_borrow_amount,
+  });
+
+  const calculatedMarketPoolData = calculateMarketPoolData(
+    query.utils,
+    parsedMarketPoolData
+  );
+
+  const coinDecimal = query.utils.getCoinDecimal(poolCoinName);
+  const maxSupplyCoin = BigNumber(
+    (await getSupplyLimit(query.utils, poolCoinName)) ?? '0'
+  )
+    .shiftedBy(-coinDecimal)
+    .toNumber();
+  const maxBorrowCoin = BigNumber(
+    (await getBorrowLimit(query.utils, poolCoinName)) ?? '0'
+  )
+    .shiftedBy(-coinDecimal)
+    .toNumber();
+
+  return {
+    coinName: poolCoinName,
+    symbol: query.utils.parseSymbol(poolCoinName),
+    coinType: query.utils.parseCoinType(poolCoinName),
+    marketCoinType: query.utils.parseMarketCoinType(poolCoinName),
+    sCoinType: query.utils.parseSCoinType(
+      query.utils.parseMarketCoinName(poolCoinName)
+    ),
+    coinWrappedType: query.utils.getCoinWrappedType(poolCoinName),
+    coinDecimal,
+    coinPrice: coinPrice ?? 0,
+    highKink: parsedMarketPoolData.highKink,
+    midKink: parsedMarketPoolData.midKink,
+    reserveFactor: parsedMarketPoolData.reserveFactor,
+    borrowWeight: parsedMarketPoolData.borrowWeight,
+    borrowFee: parsedMarketPoolData.borrowFee,
+    marketCoinSupplyAmount: parsedMarketPoolData.marketCoinSupplyAmount,
+    minBorrowAmount: parsedMarketPoolData.minBorrowAmount,
+    maxSupplyCoin,
+    maxBorrowCoin,
+    isIsolated: await isIsolatedAsset(query.utils, poolCoinName),
+    ...calculatedMarketPoolData,
+  };
 };
 
 /**

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -51,10 +51,12 @@ export const getLendings = async (
   ) as SupportStakeMarketCoins[];
 
   const coinPrices = await query.utils.getCoinPrices(poolCoinNames);
-  const marketPools = await query.getMarketPools(poolCoinNames, indexer, {
+  const marketPools = await query.getMarketPools(poolCoinNames, {
+    indexer,
     coinPrices,
   });
-  const spools = await query.getSpools(stakeMarketCoinNames, indexer, {
+  const spools = await query.getSpools(stakeMarketCoinNames, {
+    indexer,
     marketPools,
     coinPrices,
   });
@@ -128,7 +130,8 @@ export const getLending = async (
 
   marketPool =
     marketPool ??
-    (await query.getMarketPool(poolCoinName, indexer, {
+    (await query.getMarketPool(poolCoinName, {
+      indexer,
       coinPrice,
     }));
 
@@ -138,16 +141,13 @@ export const getLending = async (
   spool =
     (spool ??
     (SUPPORT_SPOOLS as readonly SupportMarketCoins[]).includes(marketCoinName))
-      ? await query.getSpool(
-          marketCoinName as SupportStakeMarketCoins,
+      ? await query.getSpool(marketCoinName as SupportStakeMarketCoins, {
           indexer,
-          {
-            marketPool,
-            coinPrices: {
-              [poolCoinName]: coinPrice,
-            },
-          }
-        )
+          marketPool,
+          coinPrices: {
+            [poolCoinName]: coinPrice,
+          },
+        })
       : undefined;
   // some pool does not have spool
   // if (!spool) throw new Error(`Failed to fetch spool for ${poolCoinName}`);
@@ -311,7 +311,7 @@ export const getObligationAccounts = async (
   indexer: boolean = false
 ) => {
   const coinPrices = await query.utils.getCoinPrices();
-  const market = await query.queryMarket(indexer, { coinPrices });
+  const market = await query.queryMarket({ indexer, coinPrices });
   const [coinAmounts, obligations] = await Promise.all([
     query.getCoinAmounts(undefined, ownerAddress),
     query.getObligations(ownerAddress),
@@ -357,7 +357,7 @@ export const getObligationAccount = async (
   ];
   coinPrices =
     coinPrices ?? (await query.utils.getCoinPrices(collateralAssetCoinNames));
-  market = market ?? (await query.queryMarket(indexer, { coinPrices }));
+  market = market ?? (await query.queryMarket({ indexer, coinPrices }));
   coinAmounts =
     coinAmounts ||
     (await query.getCoinAmounts(collateralAssetCoinNames, ownerAddress));
@@ -365,8 +365,9 @@ export const getObligationAccount = async (
   const [obligationQuery, borrowIncentivePools, borrowIncentiveAccounts] =
     await Promise.all([
       query.queryObligation(obligationId),
-      query.getBorrowIncentivePools(undefined, indexer, {
+      query.getBorrowIncentivePools(undefined, {
         coinPrices,
+        indexer,
       }),
       query.getBorrowIncentiveAccounts(obligationId),
     ]);
@@ -770,7 +771,7 @@ export const getTotalValueLocked = async (
   query: ScallopQuery,
   indexer: boolean = false
 ) => {
-  const market = await query.queryMarket(indexer);
+  const market = await query.queryMarket({ indexer });
 
   let supplyValue = BigNumber(0);
   let borrowValue = BigNumber(0);

--- a/src/queries/sCoinQuery.ts
+++ b/src/queries/sCoinQuery.ts
@@ -139,8 +139,8 @@ export const getSCoinSwapRate = async (
 
   // Get lending data for both sCoin A and sCoin B
   const marketPools = await Promise.all([
-    query.getMarketPool(fromCoinName, false),
-    query.getMarketPool(toCoinName, false),
+    query.getMarketPool(fromCoinName),
+    query.getMarketPool(toCoinName),
   ]);
   if (marketPools.some((pool) => !pool))
     throw new Error('Failed to fetch the lendings data');

--- a/src/queries/spoolQuery.ts
+++ b/src/queries/spoolQuery.ts
@@ -43,7 +43,7 @@ export const getSpools = async (
   coinPrices = coinPrices ?? (await query.utils.getCoinPrices()) ?? {};
 
   marketPools =
-    marketPools ?? (await query.getMarketPools(stakeCoinNames, indexer));
+    marketPools ?? (await query.getMarketPools(stakeCoinNames, { indexer }));
   if (!marketPools)
     throw new Error(`Fail to fetch marketPools for ${stakeCoinNames}`);
 
@@ -112,7 +112,7 @@ export const getSpool = async (
   coinPrices?: CoinPrices
 ) => {
   const coinName = query.utils.parseCoinName<SupportStakeCoins>(marketCoinName);
-  marketPool = marketPool || (await query.getMarketPool(coinName, indexer));
+  marketPool = marketPool || (await query.getMarketPool(coinName, { indexer }));
   if (!marketPool) {
     throw new Error(`Failed to fetch marketPool for ${marketCoinName}`);
   }

--- a/src/utils/indexer.ts
+++ b/src/utils/indexer.ts
@@ -11,14 +11,20 @@ export async function callMethodWithIndexerFallback(
   context: any,
   ...args: any[]
 ) {
-  const indexer = args[args.length - 1]; // Assume last argument is always `indexer`
+  const lastArgs = args[args.length - 1]; // Assume last argument is always `indexer`
 
-  if (indexer) {
+  if (typeof lastArgs === 'object' && lastArgs.indexer) {
     try {
       return await method.apply(context, args);
     } catch (e: any) {
       console.warn(`Indexer requests failed: ${e}. Retrying without indexer..`);
-      return await method.apply(context, [...args.slice(0, -1), false]);
+      return await method.apply(context, [
+        ...args.slice(0, -1),
+        {
+          ...lastArgs,
+          indexer: false,
+        },
+      ]);
     }
   }
   return await method.apply(context, args);

--- a/src/utils/tokenBucket.ts
+++ b/src/utils/tokenBucket.ts
@@ -38,8 +38,8 @@ const callWithRateLimit = async <T>(
   tokenBucket: TokenBucket,
   fn: () => Promise<T>,
   retryDelayInMs = DEFAULT_INTERVAL_IN_MS,
-  maxRetries = 30,
-  backoffFactor = 1.25 // The factor by which to increase the delay
+  maxRetries = 15,
+  backoffFactor = 2 // The factor by which to increase the delay
 ): Promise<T | null> => {
   let retries = 0;
 


### PR DESCRIPTION
### ⚠ BREAKING CHANGES

- All `indexer` parameters are moved into object parameters called `args` ([0112d9a](https://github.com/scallop-io/sui-scallop-sdk/commit/0112d9a8cf2013a54f7ce82cb742c77ab81504fd))
