### PR TITLE
fix: support borrow incentive constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.4.13](https://github.com/scallop-io/sui-scallop-sdk/compare/v1.4.12...v1.4.13) (2024-12-17)
+
+### Bugfixes
+
+- Fix `SUPPORT_BORROW_INCENTIVES` constants ([6904e80](https://github.com/scallop-io/sui-scallop-sdk/commit/6904e80cea19c4c3fec0980dace8d0a7fa063ad1))
+
 ### [1.4.12](https://github.com/scallop-io/sui-scallop-sdk/compare/v1.4.11...v1.4.12) (2024-12-17)
 
 ### Bugfixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -107,18 +107,7 @@ export const SUPPORT_WORMHOLE = [
 
 export const SUPPORT_SPOOLS_REWARDS = ['sui'] as const;
 
-export const SUPPORT_BORROW_INCENTIVE_POOLS = [
-  'sui',
-  'wusdc',
-  'wusdt',
-  'afsui',
-  'hasui',
-  'vsui',
-  'weth',
-  'sbeth',
-  'sca',
-  'usdc',
-] as const;
+export const SUPPORT_BORROW_INCENTIVE_POOLS = [...SUPPORT_POOLS] as const;
 
 export const SUPPORT_BORROW_INCENTIVE_REWARDS = [
   ...SUPPORT_POOLS,


### PR DESCRIPTION
### BUGFIXES
- Fix `SUPPORT_BORROW_INCENTIVES` constants ([6904e80](https://github.com/scallop-io/sui-scallop-sdk/commit/6904e80cea19c4c3fec0980dace8d0a7fa063ad1))