### PR TITLE
refactor: optimize object fetching by using multiGetObjects

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,6 +26,15 @@ jobs:
           pnpm run build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - name: Determine npm tag
+        id: npm_tag
+        run: |
+          if [[ "${{ github.ref_name }}" == *".alpha"* ]]; then
+            echo "tag=alpha" >> $GITHUB_ENV
+          elif [[ "${{ github.ref_name }}" == *".rc"* ]]; then
+            echo "tag=rc" >> $GITHUB_ENV
+          else
+            echo "tag=latest" >> $GITHUB_ENV
       - run: pnpm publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "1.4.15-rc.2",
+  "version": "1.4.15-rc.3",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "1.4.15-rc.3",
+  "version": "1.4.15-rc.4",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",
@@ -61,13 +61,12 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "3.2.0",
-    "@mysten/bcs": "^1.0.3",
-    "@mysten/sui": "^1.3.0",
+    "@mysten/sui": "1.3.1",
     "@noble/curves": "^1.2.0",
     "@noble/hashes": "^1.3.2",
     "@pythnetwork/price-service-client": "^1.8.2",
     "@pythnetwork/pyth-sui-js": "2.1.0",
-    "@scallop-io/sui-kit": "1.3.1-alpha.1",
+    "@scallop-io/sui-kit": "1.3.1",
     "@scure/bip39": "^1.2.1",
     "@tanstack/query-core": "5.51.15",
     "axios": "^1.6.0",
@@ -103,9 +102,10 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "@mysten/sui": "1.3.0",
-    "@scallop-io/sui-kit": "1.3.1-alpha.1",
-    "bn.js": "^5.2.1"
+    "@mysten/sui": "1.3.1",
+    "@scallop-io/sui-kit": "1.3.1",
+    "bn.js": "^5.2.1",
+    "@mysten/bcs": "^1.2.0"
   },
   "lint-staged": {
     "**/*.ts": [
@@ -166,11 +166,6 @@
           "caughtErrorsIgnorePattern": "^_"
         }
       ]
-    }
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "@mysten/sui@1.3.0": "patches/@mysten__sui@1.3.0.patch"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "1.4.14",
+  "version": "1.4.15-rc.1",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "1.4.15-rc.1",
+  "version": "1.4.15-rc.2",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-patchedDependencies:
-  '@mysten/sui@1.3.0':
-    hash: lh6jsrttufpipzcstfa7duk2iu
-    path: patches/@mysten__sui@1.3.0.patch
-
 importers:
 
   .:
@@ -17,11 +12,11 @@ importers:
         specifier: 3.2.0
         version: 3.2.0(graphql@16.9.0)
       '@mysten/bcs':
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^1.2.0
+        version: 1.2.0
       '@mysten/sui':
-        specifier: ^1.3.0
-        version: 1.3.0(patch_hash=lh6jsrttufpipzcstfa7duk2iu)(typescript@5.5.4)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.5.4)
       '@noble/curves':
         specifier: ^1.2.0
         version: 1.4.2
@@ -35,8 +30,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0(typescript@5.5.4)
       '@scallop-io/sui-kit':
-        specifier: 1.3.1-alpha.1
-        version: 1.3.1-alpha.1(typescript@5.5.4)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.5.4)
       '@scure/bip39':
         specifier: ^1.2.1
         version: 1.3.0
@@ -707,8 +702,11 @@ packages:
   '@mysten/bcs@1.0.3':
     resolution: {integrity: sha512-fc2xDj8eteP18zCNr6WStlE0Hxi7kYeY9yAzAN8oyz5EYOLas0JwScR9pAd9VR61BfIThJ+5vxQ6K7Y22lHDVQ==}
 
-  '@mysten/sui@1.3.0':
-    resolution: {integrity: sha512-KBEM+nzY30i+S1meWage5jU+upNBGSrZxY5v+oz68gj1VluldWwiaf/LtcZ3RnMcnNtkyMkeYpDL9eiMxTBTbQ==}
+  '@mysten/bcs@1.2.0':
+    resolution: {integrity: sha512-LuKonrGdGW7dq/EM6U2L9/as7dFwnhZnsnINzB/vu08Xfrj0qzWwpLOiXagAa5yZOPLK7anRZydMonczFkUPzA==}
+
+  '@mysten/sui@1.3.1':
+    resolution: {integrity: sha512-TxTYFO9ou/LOk3LQYZIJrZQJ/8UHEqYpT67MbCHYLCxGiPqAnvpIgnVBzJkpYFA/7vR0pQ1e3KELvQrYHnz2Ag==}
     engines: {node: '>=18'}
 
   '@noble/curves@1.4.2':
@@ -831,8 +829,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@scallop-io/sui-kit@1.3.1-alpha.1':
-    resolution: {integrity: sha512-JfpIWBiLwtLnrsqv7mOhbAj16QPP4XMg0kB8SmN87csEPxDaJmsjP3nm8K2rDfbnNASeBv5ED31hjuCH8HP2MA==}
+  '@scallop-io/sui-kit@1.3.1':
+    resolution: {integrity: sha512-Ydl3dVOvDnHshtO1Qg/w8C+xPHTVzo9FdYulBY3IYF9RbWYLCOusp9yrckJyXrBiKa4asOYhujKSDHXqHNfSNw==}
     engines: {node: '>=16'}
 
   '@scure/base@1.1.7':
@@ -1153,8 +1151,16 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  call-bind@1.0.7:
-    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+  call-bind-apply-helpers@1.0.1:
+    resolution: {integrity: sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.3:
+    resolution: {integrity: sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1451,6 +1457,10 @@ packages:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
     engines: {node: '>=4'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1470,12 +1480,16 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
-  es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.0.0:
+    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.19.12:
@@ -1681,8 +1695,8 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
-  get-intrinsic@1.2.4:
-    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+  get-intrinsic@1.2.6:
+    resolution: {integrity: sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==}
     engines: {node: '>= 0.4'}
 
   get-pkg-repo@4.2.1:
@@ -1743,8 +1757,9 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   gql.tada@1.8.10:
     resolution: {integrity: sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==}
@@ -1798,12 +1813,8 @@ packages:
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
-  has-proto@1.0.3:
-    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
-    engines: {node: '>= 0.4'}
-
-  has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.2:
@@ -1871,8 +1882,8 @@ packages:
     resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
     engines: {node: '>=6.0.0'}
 
-  is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
 
   is-arrayish@0.2.1:
@@ -1958,8 +1969,8 @@ packages:
     resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
     engines: {node: '>=8'}
 
-  is-typed-array@1.1.13:
-    resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
   isarray@1.0.0:
@@ -2155,6 +2166,10 @@ packages:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -2303,8 +2318,8 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
-  object.assign@4.1.5:
-    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
   once@1.4.0:
@@ -3090,8 +3105,8 @@ packages:
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
-  which-typed-array@1.1.15:
-    resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
+  which-typed-array@1.1.18:
+    resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -3728,7 +3743,11 @@ snapshots:
     dependencies:
       bs58: 6.0.0
 
-  '@mysten/sui@1.3.0(patch_hash=lh6jsrttufpipzcstfa7duk2iu)(typescript@5.5.4)':
+  '@mysten/bcs@1.2.0':
+    dependencies:
+      bs58: 6.0.0
+
+  '@mysten/sui@1.3.1(typescript@5.5.4)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       '@mysten/bcs': 1.0.3
@@ -3790,7 +3809,7 @@ snapshots:
 
   '@pythnetwork/pyth-sui-js@2.1.0(typescript@5.5.4)':
     dependencies:
-      '@mysten/sui': 1.3.0(patch_hash=lh6jsrttufpipzcstfa7duk2iu)(typescript@5.5.4)
+      '@mysten/sui': 1.3.1(typescript@5.5.4)
       '@pythnetwork/price-service-client': 1.9.0
       buffer: 6.0.3
     transitivePeerDependencies:
@@ -3851,10 +3870,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.19.0':
     optional: true
 
-  '@scallop-io/sui-kit@1.3.1-alpha.1(typescript@5.5.4)':
+  '@scallop-io/sui-kit@1.3.1(typescript@5.5.4)':
     dependencies:
-      '@mysten/bcs': 1.0.3
-      '@mysten/sui': 1.3.0(patch_hash=lh6jsrttufpipzcstfa7duk2iu)(typescript@5.5.4)
+      '@mysten/bcs': 1.2.0
+      '@mysten/sui': 1.3.1(typescript@5.5.4)
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/bip39': 1.3.0
@@ -4142,10 +4161,10 @@ snapshots:
 
   assert@2.1.0:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       is-nan: 1.3.2
       object-is: 1.1.6
-      object.assign: 4.1.5
+      object.assign: 4.1.7
       util: 0.12.5
 
   assertion-error@1.1.0: {}
@@ -4218,13 +4237,22 @@ snapshots:
 
   cac@6.7.14: {}
 
-  call-bind@1.0.7:
+  call-bind-apply-helpers@1.0.1:
     dependencies:
-      es-define-property: 1.0.0
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
+
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-define-property: 1.0.1
+      get-intrinsic: 1.2.6
       set-function-length: 1.2.2
+
+  call-bound@1.0.3:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      get-intrinsic: 1.2.6
 
   callsites@3.1.0: {}
 
@@ -4522,9 +4550,9 @@ snapshots:
 
   define-data-property@1.1.4:
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
-      gopd: 1.0.1
+      gopd: 1.2.0
 
   define-properties@1.2.1:
     dependencies:
@@ -4561,6 +4589,12 @@ snapshots:
 
   dset@3.1.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
 
   emoji-regex@10.3.0: {}
@@ -4575,11 +4609,13 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-define-property@1.0.0:
-    dependencies:
-      get-intrinsic: 1.2.4
+  es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.19.12:
     optionalDependencies:
@@ -4854,13 +4890,18 @@ snapshots:
 
   get-func-name@2.0.2: {}
 
-  get-intrinsic@1.2.4:
+  get-intrinsic@1.2.6:
     dependencies:
+      call-bind-apply-helpers: 1.0.1
+      dunder-proto: 1.0.1
+      es-define-property: 1.0.1
       es-errors: 1.3.0
+      es-object-atoms: 1.0.0
       function-bind: 1.1.2
-      has-proto: 1.0.3
-      has-symbols: 1.0.3
+      gopd: 1.2.0
+      has-symbols: 1.1.0
       hasown: 2.0.2
+      math-intrinsics: 1.1.0
 
   get-pkg-repo@4.2.1:
     dependencies:
@@ -4938,9 +4979,7 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  gopd@1.0.1:
-    dependencies:
-      get-intrinsic: 1.2.4
+  gopd@1.2.0: {}
 
   gql.tada@1.8.10(graphql@16.9.0)(typescript@5.5.4):
     dependencies:
@@ -5002,15 +5041,13 @@ snapshots:
 
   has-property-descriptors@1.0.2:
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
 
-  has-proto@1.0.3: {}
-
-  has-symbols@1.0.3: {}
+  has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -5070,9 +5107,9 @@ snapshots:
       strip-ansi: 5.2.0
       through: 2.3.8
 
-  is-arguments@1.1.1:
+  is-arguments@1.2.0:
     dependencies:
-      call-bind: 1.0.7
+      call-bound: 1.0.3
       has-tostringtag: 1.0.2
 
   is-arrayish@0.2.1: {}
@@ -5109,7 +5146,7 @@ snapshots:
 
   is-nan@1.3.2:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
 
   is-number@7.0.0: {}
@@ -5134,9 +5171,9 @@ snapshots:
     dependencies:
       text-extensions: 2.4.0
 
-  is-typed-array@1.1.13:
+  is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.15
+      which-typed-array: 1.1.18
 
   isarray@1.0.0: {}
 
@@ -5319,6 +5356,8 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  math-intrinsics@1.1.0: {}
+
   mdurl@2.0.0: {}
 
   meow@12.1.1: {}
@@ -5447,16 +5486,18 @@ snapshots:
 
   object-is@1.1.6:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
       define-properties: 1.2.1
 
   object-keys@1.1.1: {}
 
-  object.assign@4.1.5:
+  object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.3
       define-properties: 1.2.1
-      has-symbols: 1.0.3
+      es-object-atoms: 1.0.0
+      has-symbols: 1.1.0
       object-keys: 1.1.1
 
   once@1.4.0:
@@ -5772,8 +5813,8 @@ snapshots:
       define-data-property: 1.1.4
       es-errors: 1.3.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.4
-      gopd: 1.0.1
+      get-intrinsic: 1.2.6
+      gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
   shebang-command@2.0.0:
@@ -6101,10 +6142,10 @@ snapshots:
   util@0.12.5:
     dependencies:
       inherits: 2.0.4
-      is-arguments: 1.1.1
+      is-arguments: 1.2.0
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.13
-      which-typed-array: 1.1.15
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.18
 
   valibot@0.36.0: {}
 
@@ -6192,12 +6233,13 @@ snapshots:
       tr46: 1.0.1
       webidl-conversions: 4.0.2
 
-  which-typed-array@1.1.15:
+  which-typed-array@1.1.18:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.3
       for-each: 0.3.3
-      gopd: 1.0.1
+      gopd: 1.2.0
       has-tostringtag: 1.0.2
 
   which@2.0.2:

--- a/src/builders/borrowIncentiveBuilder.ts
+++ b/src/builders/borrowIncentiveBuilder.ts
@@ -97,8 +97,9 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
     };
 
     return {
-      stakeObligation: (obligationId, obligationKey) => {
-        txBlock.moveCall(
+      stakeObligation: async (obligationId, obligationKey) => {
+        await builder.moveCall(
+          txBlock,
           `${borrowIncentiveIds.borrowIncentivePkg}::user::stake`,
           [
             borrowIncentiveIds.config,
@@ -111,8 +112,13 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
           ]
         );
       },
-      stakeObligationWithVesca: (obligationId, obligationKey, veScaKey) => {
-        txBlock.moveCall(
+      stakeObligationWithVesca: async (
+        obligationId,
+        obligationKey,
+        veScaKey
+      ) => {
+        await builder.moveCall(
+          txBlock,
           `${borrowIncentiveIds.borrowIncentivePkg}::user::stake_with_ve_sca`,
           [
             borrowIncentiveIds.config,
@@ -130,8 +136,9 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
           []
         );
       },
-      unstakeObligation: (obligationId, obligationKey) => {
-        txBlock.moveCall(
+      unstakeObligation: async (obligationId, obligationKey) => {
+        await builder.moveCall(
+          txBlock,
           `${borrowIncentiveIds.borrowIncentivePkg}::user::unstake`,
           [
             borrowIncentiveIds.config,
@@ -143,9 +150,14 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
           ]
         );
       },
-      claimBorrowIncentive: (obligationId, obligationKey, rewardCoinName) => {
+      claimBorrowIncentive: async (
+        obligationId,
+        obligationKey,
+        rewardCoinName
+      ) => {
         const rewardType = builder.utils.parseCoinType(rewardCoinName);
-        return txBlock.moveCall(
+        return await builder.moveCall(
+          txBlock,
           `${borrowIncentiveIds.borrowIncentivePkg}::user::redeem_rewards`,
           [
             borrowIncentiveIds.config,
@@ -158,8 +170,9 @@ const generateBorrowIncentiveNormalMethod: GenerateBorrowIncentiveNormalMethod =
           [rewardType]
         );
       },
-      deactivateBoost: (obligation, veScaKey) => {
-        return txBlock.moveCall(
+      deactivateBoost: async (obligation, veScaKey) => {
+        await builder.moveCall(
+          txBlock,
           `${borrowIncentiveIds.borrowIncentivePkg}::user::deactivate_boost`,
           [
             borrowIncentiveIds.config,
@@ -212,7 +225,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
           );
 
         if (!obligationLocked || unstakeObligationBeforeStake) {
-          txBlock.stakeObligation(obligationArg, obligationKeyArg);
+          await txBlock.stakeObligation(obligationArg, obligationKeyArg);
         }
       },
       stakeObligationWithVeScaQuick: async (
@@ -247,9 +260,9 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
 
           const _veScaKey = bindedVeScaKey ?? veScaKey;
           if (!_veScaKey) {
-            txBlock.stakeObligation(obligationArg, obligationKeyArg);
+            await txBlock.stakeObligation(obligationArg, obligationKeyArg);
           } else {
-            txBlock.stakeObligationWithVesca(
+            await txBlock.stakeObligationWithVesca(
               obligationArg,
               obligationKeyArg,
               _veScaKey
@@ -270,7 +283,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
         );
 
         if (obligationLocked) {
-          txBlock.unstakeObligation(obligationArg, obligationKeyArg);
+          await txBlock.unstakeObligation(obligationArg, obligationKeyArg);
         }
       },
       claimBorrowIncentiveQuick: async (
@@ -287,7 +300,7 @@ const generateBorrowIncentiveQuickMethod: GenerateBorrowIncentiveQuickMethod =
             obligationKey
           );
 
-        return txBlock.claimBorrowIncentive(
+        return await txBlock.claimBorrowIncentive(
           obligationArg,
           obligationKeyArg,
           rewardCoinName

--- a/src/builders/coreBuilder.ts
+++ b/src/builders/coreBuilder.ts
@@ -189,7 +189,7 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
           coreIds.market,
           coreIds.coinDecimalsRegistry,
           borrowReferral,
-          txBlock.pure.u64(amount),
+          typeof amount === 'number' ? txBlock.pure.u64(amount) : amount,
           coreIds.xOracle,
           SUI_CLOCK_OBJECT_ID,
         ],

--- a/src/builders/coreBuilder.ts
+++ b/src/builders/coreBuilder.ts
@@ -77,38 +77,51 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
   const referralWitnessType = `${referralPkgId}::scallop_referral_program::REFERRAL_WITNESS`;
 
   return {
-    openObligation: () => {
-      const [obligation, obligationKey, obligationHotPotato] = txBlock.moveCall(
-        `${coreIds.protocolPkg}::open_obligation::open_obligation`,
-        [coreIds.version]
-      );
+    openObligation: async () => {
+      const [obligation, obligationKey, obligationHotPotato] =
+        await builder.moveCall(
+          txBlock,
+          `${coreIds.protocolPkg}::open_obligation::open_obligation`,
+          [coreIds.version]
+        );
       return [obligation, obligationKey, obligationHotPotato] as [
         NestedResult,
         NestedResult,
         NestedResult,
       ];
     },
-    returnObligation: (obligation, obligationHotPotato) =>
-      txBlock.moveCall(
+    returnObligation: async (obligation, obligationHotPotato) => {
+      await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::open_obligation::return_obligation`,
         [coreIds.version, obligation, obligationHotPotato]
-      ),
-    openObligationEntry: () =>
-      txBlock.moveCall(
+      );
+    },
+    openObligationEntry: async () => {
+      await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::open_obligation::open_obligation_entry`,
         [coreIds.version]
-      ),
-    addCollateral: (obligation, coin, collateralCoinName) => {
+      );
+    },
+    addCollateral: async (obligation, coin, collateralCoinName) => {
       const coinType = builder.utils.parseCoinType(collateralCoinName);
-      return txBlock.moveCall(
+      await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::deposit_collateral::deposit_collateral`,
         [coreIds.version, obligation, coreIds.market, coin],
         [coinType]
       );
     },
-    takeCollateral: (obligation, obligationKey, amount, collateralCoinName) => {
+    takeCollateral: async (
+      obligation,
+      obligationKey,
+      amount,
+      collateralCoinName
+    ) => {
       const coinType = builder.utils.parseCoinType(collateralCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::withdraw_collateral::withdraw_collateral`,
         [
           coreIds.version,
@@ -123,41 +136,46 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
         [coinType]
       );
     },
-    deposit: (coin, poolCoinName) => {
+    deposit: async (coin, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::mint::mint`,
         [coreIds.version, coreIds.market, coin, SUI_CLOCK_OBJECT_ID],
         [coinType]
       );
     },
-    depositEntry: (coin, poolCoinName) => {
+    depositEntry: async (coin, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::mint::mint_entry`,
         [coreIds.version, coreIds.market, coin, SUI_CLOCK_OBJECT_ID],
         [coinType]
       );
     },
-    withdraw: (marketCoin, poolCoinName) => {
+    withdraw: async (marketCoin, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::redeem::redeem`,
         [coreIds.version, coreIds.market, marketCoin, SUI_CLOCK_OBJECT_ID],
         [coinType]
       );
     },
-    withdrawEntry: (marketCoin, poolCoinName) => {
+    withdrawEntry: async (marketCoin, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::redeem::redeem_entry`,
         [coreIds.version, coreIds.market, marketCoin, SUI_CLOCK_OBJECT_ID],
         [coinType]
       );
     },
-    borrow: (obligation, obligationKey, amount, poolCoinName) => {
+    borrow: async (obligation, obligationKey, amount, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::borrow::borrow`,
         [
           coreIds.version,
@@ -172,7 +190,7 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
         [coinType]
       );
     },
-    borrowWithReferral: (
+    borrowWithReferral: async (
       obligation,
       obligationKey,
       borrowReferral,
@@ -180,7 +198,8 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
       poolCoinName
     ) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::borrow::borrow_with_referral`,
         [
           coreIds.version,
@@ -196,9 +215,10 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
         [coinType, referralWitnessType]
       );
     },
-    borrowEntry: (obligation, obligationKey, amount, poolCoinName) => {
+    borrowEntry: async (obligation, obligationKey, amount, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::borrow::borrow_entry`,
         [
           coreIds.version,
@@ -213,9 +233,10 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
         [coinType]
       );
     },
-    repay: (obligation, coin, poolCoinName) => {
+    repay: async (obligation, coin, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::repay::repay`,
         [
           coreIds.version,
@@ -227,17 +248,19 @@ const generateCoreNormalMethod: GenerateCoreNormalMethod = ({
         [coinType]
       );
     },
-    borrowFlashLoan: (amount, poolCoinName) => {
+    borrowFlashLoan: async (amount, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::flash_loan::borrow_flash_loan`,
         [coreIds.version, coreIds.market, amount],
         [coinType]
       );
     },
-    repayFlashLoan: (coin, loan, poolCoinName) => {
+    repayFlashLoan: async (coin, loan, poolCoinName) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      await builder.moveCall(
+        txBlock,
         `${coreIds.protocolPkg}::flash_loan::repay_flash_loan`,
         [coreIds.version, coreIds.market, coin, loan],
         [coinType]
@@ -273,7 +296,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
 
       if (collateralCoinName === 'sui') {
         const [suiCoin] = txBlock.splitSUIFromGas([amount]);
-        txBlock.addCollateral(obligationArg, suiCoin, collateralCoinName);
+        await txBlock.addCollateral(obligationArg, suiCoin, collateralCoinName);
       } else {
         const { leftCoin, takeCoin } = await builder.selectCoin(
           txBlock,
@@ -281,7 +304,11 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
           amount,
           sender
         );
-        txBlock.addCollateral(obligationArg, takeCoin, collateralCoinName);
+        await txBlock.addCollateral(
+          obligationArg,
+          takeCoin,
+          collateralCoinName
+        );
         txBlock.transferObjects([leftCoin], sender);
       }
     },
@@ -301,7 +328,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
         obligationInfo.obligationId
       );
       await updateOracles(builder, txBlock, updateCoinNames);
-      return txBlock.takeCollateral(
+      return await txBlock.takeCollateral(
         obligationInfo.obligationId,
         obligationInfo.obligationKey as SuiObjectArg,
         amount,
@@ -313,7 +340,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
       let marketCoinDeposit: TransactionResult | undefined;
       if (poolCoinName === 'sui') {
         const [suiCoin] = txBlock.splitSUIFromGas([amount]);
-        marketCoinDeposit = txBlock.deposit(suiCoin, poolCoinName);
+        marketCoinDeposit = await txBlock.deposit(suiCoin, poolCoinName);
       } else {
         const { leftCoin, takeCoin } = await builder.selectCoin(
           txBlock,
@@ -322,12 +349,12 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
           sender
         );
         txBlock.transferObjects([leftCoin], sender);
-        marketCoinDeposit = txBlock.deposit(takeCoin, poolCoinName);
+        marketCoinDeposit = await txBlock.deposit(takeCoin, poolCoinName);
       }
 
       // convert to sCoin
       return returnSCoin
-        ? txBlock.mintSCoin(
+        ? await txBlock.mintSCoin(
             builder.utils.parseMarketCoinName(poolCoinName),
             marketCoinDeposit
           )
@@ -347,7 +374,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
           totalAmount,
         } = await builder.selectSCoin(txBlock, sCoinName, amount, sender);
         txBlock.transferObjects([leftCoin], sender);
-        const marketCoins = txBlock.burnSCoin(sCoinName, sCoins);
+        const marketCoins = await txBlock.burnSCoin(sCoinName, sCoins);
 
         // check amount
         amount -= totalAmount;
@@ -378,7 +405,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
             sender
           );
         txBlock.transferObjects([leftCoin], sender);
-        return txBlock.withdraw(walletMarketCoins, poolCoinName);
+        return await txBlock.withdraw(walletMarketCoins, poolCoinName);
       }
     },
     borrowQuick: async (amount, poolCoinName, obligationId, obligationKey) => {
@@ -394,7 +421,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
         )) ?? [];
       const updateCoinNames = [...obligationCoinNames, poolCoinName];
       await updateOracles(builder, txBlock, updateCoinNames);
-      return txBlock.borrow(
+      return await txBlock.borrow(
         obligationInfo.obligationId,
         obligationInfo.obligationKey as SuiObjectArg,
         amount,
@@ -420,7 +447,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
         )) ?? [];
       const updateCoinNames = [...obligationCoinNames, poolCoinName];
       await updateOracles(builder, txBlock, updateCoinNames);
-      return txBlock.borrowWithReferral(
+      return await txBlock.borrowWithReferral(
         obligationInfo.obligationId,
         obligationInfo.obligationKey as SuiObjectArg,
         borrowReferral,
@@ -438,7 +465,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
 
       if (poolCoinName === 'sui') {
         const [suiCoin] = txBlock.splitSUIFromGas([amount]);
-        return txBlock.repay(
+        return await txBlock.repay(
           obligationInfo.obligationId,
           suiCoin,
           poolCoinName
@@ -451,7 +478,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
           sender
         );
         txBlock.transferObjects([leftCoin], sender);
-        return txBlock.repay(
+        return await txBlock.repay(
           obligationInfo.obligationId,
           takeCoin,
           poolCoinName
@@ -459,7 +486,7 @@ const generateCoreQuickMethod: GenerateCoreQuickMethod = ({
       }
     },
     updateAssetPricesQuick: async (assetCoinNames) => {
-      return updateOracles(builder, txBlock, assetCoinNames);
+      return await updateOracles(builder, txBlock, assetCoinNames);
     },
   };
 };

--- a/src/builders/loyaltyProgramBuilder.ts
+++ b/src/builders/loyaltyProgramBuilder.ts
@@ -23,8 +23,9 @@ const generateLoyaltyProgramNormalMethod: GenerateLoyaltyProgramNormalMethod =
     };
 
     return {
-      claimLoyaltyRevenue: (veScaKey) => {
-        return txBlock.moveCall(
+      claimLoyaltyRevenue: async (veScaKey) => {
+        return await builder.moveCall(
+          txBlock,
           `${loyaltyProgramIds.loyaltyProgramPkgId}::reward_pool::redeem_reward`,
           [loyaltyProgramIds.rewardPool, veScaKey]
         );
@@ -43,7 +44,7 @@ const generateLoyaltyProgramQuickMethod: GenerateLoyaltyProgramQuickMethod = ({
       if (!veScaKey) throw new Error(`No veScaKey found for user ${sender}`);
 
       // claim the pending reward
-      const rewardCoin = txBlock.claimLoyaltyRevenue(veScaKey);
+      const rewardCoin = await txBlock.claimLoyaltyRevenue(veScaKey);
 
       // get existing sca coin to merge with
       await builder.utils.mergeSimilarCoins(

--- a/src/builders/referralBuilder.ts
+++ b/src/builders/referralBuilder.ts
@@ -34,8 +34,9 @@ const generateReferralNormalMethod: GenerateReferralNormalMethod = ({
   const veScaTable = builder.address.get('vesca.table');
 
   return {
-    bindToReferral: (veScaKeyId: string) => {
-      return txBlock.moveCall(
+    bindToReferral: async (veScaKeyId: string) => {
+      await builder.moveCall(
+        txBlock,
         `${referralIds.referralPgkId}::referral_bindings::bind_ve_sca_referrer`,
         [
           referralIds.referralBindings,
@@ -46,9 +47,10 @@ const generateReferralNormalMethod: GenerateReferralNormalMethod = ({
         []
       );
     },
-    claimReferralTicket: (poolCoinName: SupportCoins) => {
+    claimReferralTicket: async (poolCoinName: SupportCoins) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${referralIds.referralPgkId}::scallop_referral_program::claim_ve_sca_referral_ticket`,
         [
           referralIds.version,
@@ -61,9 +63,13 @@ const generateReferralNormalMethod: GenerateReferralNormalMethod = ({
         [coinType]
       );
     },
-    burnReferralTicket: (ticket: SuiObjectArg, poolCoinName: SupportCoins) => {
+    burnReferralTicket: async (
+      ticket: SuiObjectArg,
+      poolCoinName: SupportCoins
+    ) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      await builder.moveCall(
+        txBlock,
         `${referralIds.referralPgkId}::scallop_referral_program::burn_ve_sca_referral_ticket`,
         [
           referralIds.version,
@@ -74,12 +80,13 @@ const generateReferralNormalMethod: GenerateReferralNormalMethod = ({
         [coinType]
       );
     },
-    claimReferralRevenue: (
+    claimReferralRevenue: async (
       veScaKey: SuiObjectArg,
       poolCoinName: SupportCoins
     ) => {
       const coinType = builder.utils.parseCoinType(poolCoinName);
-      return txBlock.moveCall(
+      return await builder.moveCall(
+        txBlock,
         `${referralIds.referralPgkId}::referral_revenue_pool::claim_revenue_with_ve_sca_key`,
         [
           referralIds.version,
@@ -106,10 +113,16 @@ const generateReferralQuickMethod: GenerateReferralQuickMethod = ({
       const objToTransfer: SuiObjectArg[] = [];
       for (const coinName of coinNames) {
         if (coinName === 'sui') {
-          const rewardCoin = txBlock.claimReferralRevenue(veScaKey, coinName);
+          const rewardCoin = await txBlock.claimReferralRevenue(
+            veScaKey,
+            coinName
+          );
           objToTransfer.push(rewardCoin);
         } else {
-          const rewardCoin = txBlock.claimReferralRevenue(veScaKey, coinName);
+          const rewardCoin = await txBlock.claimReferralRevenue(
+            veScaKey,
+            coinName
+          );
           try {
             // get the matching user coin if exists
             const coins = await builder.suiKit.suiInteractor.selectCoins(

--- a/src/builders/sCoinBuilder.ts
+++ b/src/builders/sCoinBuilder.ts
@@ -20,8 +20,9 @@ const generateSCoinNormalMethod: GenerateSCoinNormalMethod = ({
   };
 
   return {
-    mintSCoin: (marketCoinName, marketCoin) => {
-      return txBlock.moveCall(
+    mintSCoin: async (marketCoinName, marketCoin) => {
+      return await builder.moveCall(
+        txBlock,
         `${sCoinPkgIds.pkgId}::s_coin_converter::mint_s_coin`,
         [builder.utils.getSCoinTreasury(marketCoinName), marketCoin],
         [
@@ -30,8 +31,9 @@ const generateSCoinNormalMethod: GenerateSCoinNormalMethod = ({
         ]
       );
     },
-    burnSCoin: (sCoinName, sCoin) => {
-      return txBlock.moveCall(
+    burnSCoin: async (sCoinName, sCoin) => {
+      return await builder.moveCall(
+        txBlock,
         `${sCoinPkgIds.pkgId}::s_coin_converter::burn_s_coin`,
         [builder.utils.getSCoinTreasury(sCoinName), sCoin],
         [
@@ -58,7 +60,7 @@ const generateSCoinQuickMethod: GenerateSCoinQuickMethod = ({
       );
 
       txBlock.transferObjects([leftCoin], sender);
-      return txBlock.mintSCoin(marketCoinName, takeCoin);
+      return await txBlock.mintSCoin(marketCoinName, takeCoin);
     },
     burnSCoinQuick: async (sCoinName, amount) => {
       const sender = requireSender(txBlock);
@@ -70,7 +72,7 @@ const generateSCoinQuickMethod: GenerateSCoinQuickMethod = ({
       );
 
       txBlock.transferObjects([leftCoin], sender);
-      return txBlock.burnSCoin(sCoinName, takeCoin);
+      return await txBlock.burnSCoin(sCoinName, takeCoin);
     },
   };
 };

--- a/src/builders/vescaBuilder.ts
+++ b/src/builders/vescaBuilder.ts
@@ -89,8 +89,9 @@ const generateNormalVeScaMethod: GenerateVeScaNormalMethod = ({
   };
 
   return {
-    lockSca: (scaCoin, unlockAtInSecondTimestamp) => {
-      return txBlock.moveCall(
+    lockSca: async (scaCoin, unlockAtInSecondTimestamp) => {
+      return await builder.moveCall(
+        txBlock,
         `${veScaIds.pkgId}::ve_sca::mint_ve_sca_key`,
         [
           veScaIds.config,
@@ -103,8 +104,9 @@ const generateNormalVeScaMethod: GenerateVeScaNormalMethod = ({
         []
       );
     },
-    extendLockPeriod: (veScaKey, newUnlockAtInSecondTimestamp) => {
-      txBlock.moveCall(
+    extendLockPeriod: async (veScaKey, newUnlockAtInSecondTimestamp) => {
+      await builder.moveCall(
+        txBlock,
         `${veScaIds.pkgId}::ve_sca::extend_lock_period`,
         [
           veScaIds.config,
@@ -117,8 +119,9 @@ const generateNormalVeScaMethod: GenerateVeScaNormalMethod = ({
         []
       );
     },
-    extendLockAmount: (veScaKey, scaCoin) => {
-      txBlock.moveCall(
+    extendLockAmount: async (veScaKey, scaCoin) => {
+      await builder.moveCall(
+        txBlock,
         `${veScaIds.pkgId}::ve_sca::lock_more_sca`,
         [
           veScaIds.config,
@@ -131,8 +134,13 @@ const generateNormalVeScaMethod: GenerateVeScaNormalMethod = ({
         []
       );
     },
-    renewExpiredVeSca: (veScaKey, scaCoin, newUnlockAtInSecondTimestamp) => {
-      txBlock.moveCall(
+    renewExpiredVeSca: async (
+      veScaKey,
+      scaCoin,
+      newUnlockAtInSecondTimestamp
+    ) => {
+      await builder.moveCall(
+        txBlock,
         `${veScaIds.pkgId}::ve_sca::renew_expired_ve_sca`,
         [
           veScaIds.config,
@@ -146,8 +154,9 @@ const generateNormalVeScaMethod: GenerateVeScaNormalMethod = ({
         []
       );
     },
-    redeemSca: (veScaKey) => {
-      return txBlock.moveCall(
+    redeemSca: async (veScaKey) => {
+      return await builder.moveCall(
+        txBlock,
         `${veScaIds.pkgId}::ve_sca::redeem`,
         [
           veScaIds.config,
@@ -159,8 +168,9 @@ const generateNormalVeScaMethod: GenerateVeScaNormalMethod = ({
         []
       );
     },
-    mintEmptyVeSca: () => {
-      return txBlock.moveCall(
+    mintEmptyVeSca: async () => {
+      return await builder.moveCall(
+        txBlock,
         `${veScaIds.pkgId}::ve_sca::mint_ve_sca_placeholder_key`,
         [veScaIds.config, veScaIds.table],
         []
@@ -346,7 +356,7 @@ const generateQuickVeScaMethod: GenerateVeScaQuickMethod = ({
       checkVesca(veSca?.unlockAt);
 
       if (veSca) {
-        const sca = txBlock.redeemSca(veSca.keyId);
+        const sca = await txBlock.redeemSca(veSca.keyId);
         if (transferSca) {
           txBlock.transferObjects([sca], sender);
           return;

--- a/src/constants/poolAddress.ts
+++ b/src/constants/poolAddress.ts
@@ -17,30 +17,10 @@ export const POOL_ADDRESSES: OptionalKeys<
       supplyLimitKey?: string;
       borrowLimitKey?: string;
       isolatedAssetKey?: string;
+      coinDecimalId?: string;
     }
   >
 > = {
-  sbeth: {
-    lendingPoolAddress:
-      '0xaa34c938e0394e5186c7dc626ad69be96af2194b23fdc6ac1c63090e399f5ba4',
-    collateralPoolAddress:
-      '0xce0549a1cbe952e734f56646988e6b02bbae14667889a60e24d0d03540a6119f',
-    borrowDynamic:
-      '0x7bbe75e8b924229f2f2110838ff612ea66e670fa3766759515dee78f617b1ea3',
-    interestModel:
-      '0x9e6cae260d05155785a1904d24e6abc98368509c5752c8a9cec15a35aabc1512',
-    riskModel:
-      '0xcf10334cfee675ecea2d2fee37b0f7cd2835c84b8b5692a853021debe6af80ab',
-    borrowFeeKey:
-      '0x4298c8b6afe7a42a8e3ff93773fb9769529fe6d37e085ab411acf2ba2a44a931',
-    supplyLimitKey:
-      '0x812fe508b78d3e0817149c0b39976221ddb267b5cc9514e81679f9b9a2f3624c',
-    borrowLimitKey:
-      '0x165c274c67eda2b0d13563124741fffd0ce7d643f4c1c4b59d7e53a83796ae25',
-    isolatedAssetKey: undefined,
-    spool: undefined,
-    spoolReward: undefined,
-  },
   usdc: {
     lendingPoolAddress:
       '0xd3be98bf540f7603eeb550c0c0a19dbfc78822f25158b5fa84ebd9609def415f',
@@ -62,49 +42,35 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0x0b5f5f413bd3799e4052c37311966c77f3a4545eb125d2e93e67a68478021918',
     spoolReward:
       '0x85ed6ed72ea97c35dbf0cdc7ed6fbc48d8ec15de9b17c74bf4512df8a6d7f166',
+    sCoinTreasury:
+      '0xbe6b63021f3d82e0e7e977cdd718ed7c019cf2eba374b7b546220402452f938e',
+    coinDecimalId:
+      '0x69b7a7c3c200439c1b5f3b19d7d495d5966d5f08de66c69276152f8db3992ec6',
   },
-  wbtc: {
+  sbeth: {
     lendingPoolAddress:
-      '0x65cc08a5aca0a0b8d72e1993ded8d145f06dd102fd0d8f285b92934faed564ab',
+      '0xaa34c938e0394e5186c7dc626ad69be96af2194b23fdc6ac1c63090e399f5ba4',
     collateralPoolAddress:
-      '0x1aa4e5cf743cd797b4eb8bf1e614f80ae2cf556ced426cddaaf190ffcd0e59c3',
+      '0xce0549a1cbe952e734f56646988e6b02bbae14667889a60e24d0d03540a6119f',
     borrowDynamic:
-      '0x6f97dcf54158a5d08f359a213a41e347bc1e6316414288dc1e1b674dc008742e',
+      '0x7bbe75e8b924229f2f2110838ff612ea66e670fa3766759515dee78f617b1ea3',
     interestModel:
-      '0x582b915cca0ffca9576a7cedd505d0fd7cb146e9521ccf10e7453ed93705684d',
+      '0x9e6cae260d05155785a1904d24e6abc98368509c5752c8a9cec15a35aabc1512',
     riskModel:
-      '0x1d0a242bf1682e259112239720da19d3155dd99d70b1f4b3b973eecbab858911',
+      '0xcf10334cfee675ecea2d2fee37b0f7cd2835c84b8b5692a853021debe6af80ab',
     borrowFeeKey:
-      '0x654ab7e8ff6d9ef04da697e1f12ca21eaf72ebb495daf877e0776e65187dcb92',
+      '0x4298c8b6afe7a42a8e3ff93773fb9769529fe6d37e085ab411acf2ba2a44a931',
     supplyLimitKey:
-      '0xac3b0d17df9f98aa2798c54405cf1d8d5356ef22f76f02d150cbe5195e9f3a36',
+      '0x812fe508b78d3e0817149c0b39976221ddb267b5cc9514e81679f9b9a2f3624c',
     borrowLimitKey:
-      '0x231e13ba6b1eb26c562f4a125778d3152f9a77e31f124bd6012e234a73012169',
+      '0x165c274c67eda2b0d13563124741fffd0ce7d643f4c1c4b59d7e53a83796ae25',
     isolatedAssetKey: undefined,
     spool: undefined,
     spoolReward: undefined,
-  },
-  wusdc: {
-    lendingPoolAddress:
-      '0x2f4df5e1368fbbdaa5c712d28b837b3d41c2d3872979ccededcdfdac55ff8a93',
-    collateralPoolAddress:
-      '0x94cf69158114c5b242d2ee5d0149a335bddf3b9c9a6ba919cca58097a4814980',
-    borrowDynamic:
-      '0x0464d117908b52fc75f7f85322a47caa078ef56f48681bcfdcb630a66f2591e6',
-    interestModel:
-      '0xd72e2b5ba486752939d6dfb86a67b86ce9a60c83cb8fb893caac54a0f112577f',
-    riskModel:
-      '0xb74035de8f70c1531ceb8e2e8c152d6b8db24c8a9fe7bbf6f75dbf7c6700a0a3',
-    borrowFeeKey:
-      '0x76dcf1acbd9951fe3d1a3fe28403fec089ffe53a7c7d6c77e3ea97033a63581a',
-    supplyLimitKey:
-      '0x7b302196907e87c5d5872f2e6f40628d110170f994e0e08bc607bded001958c3',
-    borrowLimitKey:
-      '0x97f1502ce994db0bcb15aac1760d174def9e88e97cd2262eed54521ee2c19f81',
-    isolatedAssetKey: undefined,
-    spool: '0x4ace6648ddc64e646ba47a957c562c32c9599b3bba8f5ac1aadb2ae23a2f8ca0',
-    spoolReward:
-      '0xf4268cc9b9413b9bfe09e8966b8de650494c9e5784bf0930759cfef4904daff8',
+    sCoinTreasury:
+      '0xfd0f02def6358a1f266acfa1493d4707ee8387460d434fb667d63d755ff907ed',
+    coinDecimalId:
+      '0x89b04ba87f8832d4d76e17a1c9dce72eb3e64d372cf02012b8d2de5384faeef0',
   },
   weth: {
     lendingPoolAddress:
@@ -127,6 +93,61 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0xeec40beccb07c575bebd842eeaabb835f77cd3dab73add433477e57f583a6787',
     spoolReward:
       '0x957de68a18d87817de8309b30c1ec269a4d87ae513abbeed86b5619cb9ce1077',
+    sCoinTreasury:
+      '0x4b7f5da0e306c9d52490a0c1d4091e653d6b89778b9b4f23c877e534e4d9cd21',
+    coinDecimalId:
+      '0x8900e4ceede3363bef086d6b50ca89d816d0e90bf6bc46efefe1f8455e08f50f',
+  },
+  wbtc: {
+    lendingPoolAddress:
+      '0x65cc08a5aca0a0b8d72e1993ded8d145f06dd102fd0d8f285b92934faed564ab',
+    collateralPoolAddress:
+      '0x1aa4e5cf743cd797b4eb8bf1e614f80ae2cf556ced426cddaaf190ffcd0e59c3',
+    borrowDynamic:
+      '0x6f97dcf54158a5d08f359a213a41e347bc1e6316414288dc1e1b674dc008742e',
+    interestModel:
+      '0x582b915cca0ffca9576a7cedd505d0fd7cb146e9521ccf10e7453ed93705684d',
+    riskModel:
+      '0x1d0a242bf1682e259112239720da19d3155dd99d70b1f4b3b973eecbab858911',
+    borrowFeeKey:
+      '0x654ab7e8ff6d9ef04da697e1f12ca21eaf72ebb495daf877e0776e65187dcb92',
+    supplyLimitKey:
+      '0xac3b0d17df9f98aa2798c54405cf1d8d5356ef22f76f02d150cbe5195e9f3a36',
+    borrowLimitKey:
+      '0x231e13ba6b1eb26c562f4a125778d3152f9a77e31f124bd6012e234a73012169',
+    isolatedAssetKey: undefined,
+    spool: undefined,
+    spoolReward: undefined,
+    sCoinTreasury:
+      '0xe2883934ea42c99bc998bbe0f01dd6d27aa0e27a56455707b1b34e6a41c20baa',
+    coinDecimalId:
+      '0x5d3c6e60eeff8a05b693b481539e7847dfe33013e7070cdcb387f5c0cac05dfd',
+  },
+  wusdc: {
+    lendingPoolAddress:
+      '0x2f4df5e1368fbbdaa5c712d28b837b3d41c2d3872979ccededcdfdac55ff8a93',
+    collateralPoolAddress:
+      '0x94cf69158114c5b242d2ee5d0149a335bddf3b9c9a6ba919cca58097a4814980',
+    borrowDynamic:
+      '0x0464d117908b52fc75f7f85322a47caa078ef56f48681bcfdcb630a66f2591e6',
+    interestModel:
+      '0xd72e2b5ba486752939d6dfb86a67b86ce9a60c83cb8fb893caac54a0f112577f',
+    riskModel:
+      '0xb74035de8f70c1531ceb8e2e8c152d6b8db24c8a9fe7bbf6f75dbf7c6700a0a3',
+    borrowFeeKey:
+      '0x76dcf1acbd9951fe3d1a3fe28403fec089ffe53a7c7d6c77e3ea97033a63581a',
+    supplyLimitKey:
+      '0x7b302196907e87c5d5872f2e6f40628d110170f994e0e08bc607bded001958c3',
+    borrowLimitKey:
+      '0x97f1502ce994db0bcb15aac1760d174def9e88e97cd2262eed54521ee2c19f81',
+    isolatedAssetKey: undefined,
+    spool: '0x4ace6648ddc64e646ba47a957c562c32c9599b3bba8f5ac1aadb2ae23a2f8ca0',
+    spoolReward:
+      '0xf4268cc9b9413b9bfe09e8966b8de650494c9e5784bf0930759cfef4904daff8',
+    sCoinTreasury:
+      '0x50c5cfcbcca3aaacab0984e4d7ad9a6ad034265bebb440f0d1cd688ec20b2548',
+    coinDecimalId:
+      '0x4fbf84f3029bd0c0b77164b587963be957f853eccf834a67bb9ecba6ec80f189',
   },
   wusdt: {
     lendingPoolAddress:
@@ -149,6 +170,10 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0xcb328f7ffa7f9342ed85af3fdb2f22919e1a06dfb2f713c04c73543870d7548f',
     spoolReward:
       '0x2c9f934d67a5baa586ceec2cc24163a2f049a6af3d5ba36b84d8ac40f25c4080',
+    sCoinTreasury:
+      '0x1f02e2fed702b477732d4ad6044aaed04f2e8e586a169153694861a901379df0',
+    coinDecimalId:
+      '0xfb0e3eb97dd158a5ae979dddfa24348063843c5b20eb8381dd5fa7c93699e45c',
   },
   sui: {
     lendingPoolAddress:
@@ -171,6 +196,10 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0x4f0ba970d3c11db05c8f40c64a15b6a33322db3702d634ced6536960ab6f3ee4',
     spoolReward:
       '0x162250ef72393a4ad3d46294c4e1bdfcb03f04c869d390e7efbfc995353a7ee9',
+    sCoinTreasury:
+      '0x5c1678c8261ac9eec024d4d630006a9f55c80dc0b1aa38a003fcb1d425818c6b',
+    coinDecimalId:
+      '0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3',
   },
   wapt: {
     lendingPoolAddress:
@@ -190,28 +219,9 @@ export const POOL_ADDRESSES: OptionalKeys<
     isolatedAssetKey: undefined,
     spool: undefined,
     spoolReward: undefined,
-  },
-  afsui: {
-    lendingPoolAddress:
-      '0x9b942a24ce390b7f5016d34a0217057bf9487b92aa6d7cc9894271dbbe62471a',
-    collateralPoolAddress:
-      '0xe5e56f5c0e3072760b21f9d49a5cc793f37d736c412a9065c16e1265c74e6341',
-    borrowDynamic:
-      '0x1c76d4df9506154a117bbac0f5e005d8a9c0d9ca60e3fe0c9d080006f6f54e81',
-    interestModel:
-      '0xb155c536b37c9601baaa734ad1dd0ef335b2b597aceb8d3ecee41a43f94dcd70',
-    riskModel:
-      '0x75371b1d04b5bebc0738af548ba64ea658e74f78228ec8014336d8eebb992312',
-    borrowFeeKey:
-      '0xabc6422db2d4ee01635ddaeaa44ba68370eebd785d2c4632515f841ae9bc47d9',
-    supplyLimitKey:
-      '0x61a2054eb37f543c0d774da57f2c9542aad8d79a197f748ac08ef5df6cc47028',
-    borrowLimitKey:
-      '0x4459498a043872cd107ea917493fee0baf2d37a273c7538e1d6581cc61b92af8',
-    isolatedAssetKey: undefined,
-    spool: '0xeedf438abcaa6ce4d9625ffca110920592d5867e4c5637d84ad9f466c4feb800',
-    spoolReward:
-      '0x89255a2f86ed7fbfef35ab8b7be48cc7667015975be2685dd9a55a9a64baf76e',
+    sCoinTreasury: undefined,
+    coinDecimalId:
+      '0xc969c5251f372c0f34c32759f1d315cf1ea0ee5e4454b52aea08778eacfdd0a8',
   },
   wsol: {
     lendingPoolAddress:
@@ -233,6 +243,10 @@ export const POOL_ADDRESSES: OptionalKeys<
     isolatedAssetKey: undefined,
     spool: undefined,
     spoolReward: undefined,
+    sCoinTreasury:
+      '0x760fd66f5be869af4382fa32b812b3c67f0eca1bb1ed7a5578b21d56e1848819',
+    coinDecimalId:
+      '0x4d2c39082b4477e3e79dc4562d939147ab90c42fc5f3e4acf03b94383cd69b6e',
   },
   cetus: {
     lendingPoolAddress:
@@ -255,6 +269,36 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0xac1bb13bf4472a637c18c2415fb0e3c1227ea2bcf35242e50563c98215bd298e',
     spoolReward:
       '0x6835c1224126a45086fc6406adc249e3f30df18d779ca4f4e570e38716a17f3f',
+    sCoinTreasury:
+      '0xa283c63488773c916cb3d6c64109536160d5eb496caddc721eb39aad2977d735',
+    coinDecimalId:
+      '0x4c0dce55eff2db5419bbd2d239d1aa22b4a400c01bbb648b058a9883989025da',
+  },
+  afsui: {
+    lendingPoolAddress:
+      '0x9b942a24ce390b7f5016d34a0217057bf9487b92aa6d7cc9894271dbbe62471a',
+    collateralPoolAddress:
+      '0xe5e56f5c0e3072760b21f9d49a5cc793f37d736c412a9065c16e1265c74e6341',
+    borrowDynamic:
+      '0x1c76d4df9506154a117bbac0f5e005d8a9c0d9ca60e3fe0c9d080006f6f54e81',
+    interestModel:
+      '0xb155c536b37c9601baaa734ad1dd0ef335b2b597aceb8d3ecee41a43f94dcd70',
+    riskModel:
+      '0x75371b1d04b5bebc0738af548ba64ea658e74f78228ec8014336d8eebb992312',
+    borrowFeeKey:
+      '0xabc6422db2d4ee01635ddaeaa44ba68370eebd785d2c4632515f841ae9bc47d9',
+    supplyLimitKey:
+      '0x61a2054eb37f543c0d774da57f2c9542aad8d79a197f748ac08ef5df6cc47028',
+    borrowLimitKey:
+      '0x4459498a043872cd107ea917493fee0baf2d37a273c7538e1d6581cc61b92af8',
+    isolatedAssetKey: undefined,
+    spool: '0xeedf438abcaa6ce4d9625ffca110920592d5867e4c5637d84ad9f466c4feb800',
+    spoolReward:
+      '0x89255a2f86ed7fbfef35ab8b7be48cc7667015975be2685dd9a55a9a64baf76e',
+    sCoinTreasury:
+      '0x55f4dfe9e40bc4cc11c70fcb1f3daefa2bdc330567c58d4f0792fbd9f9175a62',
+    coinDecimalId:
+      '0x2f9217f533e51334873a39b8026a4aa6919497b47f49d0986a4f1aec66f8a34d',
   },
   hasui: {
     lendingPoolAddress:
@@ -277,6 +321,10 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0xa6148bc1b623e936d39a952ceb5bea79e8b37228a8f595067bf1852efd3c34aa',
     spoolReward:
       '0x6f3563644d3e2ef13176dbf9d865bd93479df60ccbe07b7e66db57f6309f5a66',
+    sCoinTreasury:
+      '0x404ccc1404d74a90eb6f9c9d4b6cda6d417fb03189f80d9070a35e5dab1df0f5',
+    coinDecimalId:
+      '0x2c5f33af93f6511df699aaaa5822d823aac6ed99d4a0de2a4a50b3afa0172e24',
   },
   vsui: {
     lendingPoolAddress:
@@ -299,6 +347,10 @@ export const POOL_ADDRESSES: OptionalKeys<
     spool: '0x69ce8e537e750a95381e6040794afa5ab1758353a1a2e1de7760391b01f91670',
     spoolReward:
       '0xbca914adce058ad0902c7f3cfcd698392a475f00dcfdc3f76001d0370b98777a',
+    sCoinTreasury:
+      '0xc06688ee1af25abc286ffb1d18ce273d1d5907cd1064c25f4e8ca61ea989c1d1',
+    coinDecimalId:
+      '0xabd84a23467b33854ab25cf862006fd97479f8f6f53e50fe732c43a274d939bd',
   },
   sca: {
     lendingPoolAddress:
@@ -320,26 +372,10 @@ export const POOL_ADDRESSES: OptionalKeys<
     isolatedAssetKey: undefined,
     spool: undefined,
     spoolReward: undefined,
-  },
-  deep: {
-    lendingPoolAddress:
-      '0xf4a67ffb43da1e1c61c049f188f19463ea8dbbf2d5ef4722d6df854ff1b1cc03',
-    collateralPoolAddress: undefined,
-    borrowDynamic:
-      '0x95e00d7466f97a100e70f08bd37788dc49335796f6f49fab996d40dd0681c6d3',
-    interestModel:
-      '0x4143c298506a332d92ea8a995e6f3991ee3215f58f6fc6441752835d275b9a69',
-    riskModel: undefined,
-    borrowFeeKey:
-      '0xb14ee43f4ad2a2c40bac8c4406a401690e93c982e289cf3802fedf74a159cab2',
-    supplyLimitKey:
-      '0x599528fdfdc253e90dfd0acf4f4a166b391e2aac1ca6528abbff63225b548fee',
-    borrowLimitKey:
-      '0xf4217e8ef9d9c32e8992092e910a77535a8124c19b8a762a673f227f5f765a4e',
-    isolatedAssetKey:
-      '0x208d3a24ba369dcfc8f0387333d1512b98199eb150d2f2a69359ff708cf761e3',
-    spool: undefined,
-    spoolReward: undefined,
+    sCoinTreasury:
+      '0xe04bfc95e00252bd654ee13c08edef9ac5e4b6ae4074e8390db39e9a0109c529',
+    coinDecimalId:
+      '0x5d26a1e9a55c88147ac870bfa31b729d7f49f8804b8b3adfdf3582d301cca844',
   },
   fud: {
     lendingPoolAddress:
@@ -360,5 +396,33 @@ export const POOL_ADDRESSES: OptionalKeys<
       '0xfcb533e9e4e31f9c9f32d6cbf7fbb3425f1d60474e229a363a2dc7f835d587e2',
     spool: undefined,
     spoolReward: undefined,
+    sCoinTreasury:
+      '0xf25212f11d182decff7a86165699a73e3d5787aced203ca539f43cfbc10db867',
+    coinDecimalId:
+      '0x01087411ef48aaac1eb6e24803213e3a60a03b147dac930e5e341f17a85e524e',
+  },
+  deep: {
+    lendingPoolAddress:
+      '0xf4a67ffb43da1e1c61c049f188f19463ea8dbbf2d5ef4722d6df854ff1b1cc03',
+    collateralPoolAddress: undefined,
+    borrowDynamic:
+      '0x95e00d7466f97a100e70f08bd37788dc49335796f6f49fab996d40dd0681c6d3',
+    interestModel:
+      '0x4143c298506a332d92ea8a995e6f3991ee3215f58f6fc6441752835d275b9a69',
+    riskModel: undefined,
+    borrowFeeKey:
+      '0xb14ee43f4ad2a2c40bac8c4406a401690e93c982e289cf3802fedf74a159cab2',
+    supplyLimitKey:
+      '0x599528fdfdc253e90dfd0acf4f4a166b391e2aac1ca6528abbff63225b548fee',
+    borrowLimitKey:
+      '0xf4217e8ef9d9c32e8992092e910a77535a8124c19b8a762a673f227f5f765a4e',
+    isolatedAssetKey:
+      '0x208d3a24ba369dcfc8f0387333d1512b98199eb150d2f2a69359ff708cf761e3',
+    spool: undefined,
+    spoolReward: undefined,
+    sCoinTreasury:
+      '0xc63838fabe37b25ad897392d89876d920f5e0c6a406bf3abcb84753d2829bc88',
+    coinDecimalId:
+      '0x6e60b051a08fa836f5a7acd7c464c8d9825bc29c44657fe170fe9b8e1e4770c0',
   },
 };

--- a/src/constants/poolAddress.ts
+++ b/src/constants/poolAddress.ts
@@ -9,6 +9,7 @@ export const POOL_ADDRESSES: OptionalKeys<
       collateralPoolAddress?: string; // not all pool has collateral
       spool?: string;
       spoolReward?: string;
+      sCoinTreasury?: string;
       borrowDynamic?: string;
       interestModel?: string;
       riskModel?: string;

--- a/src/constants/poolAddress.ts
+++ b/src/constants/poolAddress.ts
@@ -1,102 +1,363 @@
-import { SupportPoolCoins } from 'src/types';
+import { OptionalKeys, SupportPoolCoins } from 'src/types';
 
-export const POOL_ADDRESSES: Record<
-  SupportPoolCoins,
-  {
-    lendingPoolAddress: string;
-    collateralPoolAddress?: string; // not all pool has collateral
-  }
+export const POOL_ADDRESSES: OptionalKeys<
+  Record<
+    SupportPoolCoins,
+    {
+      coinType?: string;
+      lendingPoolAddress?: string;
+      collateralPoolAddress?: string; // not all pool has collateral
+      spool?: string;
+      spoolReward?: string;
+      borrowDynamic?: string;
+      interestModel?: string;
+      riskModel?: string;
+      borrowFeeKey?: string;
+      supplyLimitKey?: string;
+      borrowLimitKey?: string;
+      isolatedAssetKey?: string;
+    }
+  >
 > = {
+  sbeth: {
+    lendingPoolAddress:
+      '0xaa34c938e0394e5186c7dc626ad69be96af2194b23fdc6ac1c63090e399f5ba4',
+    collateralPoolAddress:
+      '0xce0549a1cbe952e734f56646988e6b02bbae14667889a60e24d0d03540a6119f',
+    borrowDynamic:
+      '0x7bbe75e8b924229f2f2110838ff612ea66e670fa3766759515dee78f617b1ea3',
+    interestModel:
+      '0x9e6cae260d05155785a1904d24e6abc98368509c5752c8a9cec15a35aabc1512',
+    riskModel:
+      '0xcf10334cfee675ecea2d2fee37b0f7cd2835c84b8b5692a853021debe6af80ab',
+    borrowFeeKey:
+      '0x4298c8b6afe7a42a8e3ff93773fb9769529fe6d37e085ab411acf2ba2a44a931',
+    supplyLimitKey:
+      '0x812fe508b78d3e0817149c0b39976221ddb267b5cc9514e81679f9b9a2f3624c',
+    borrowLimitKey:
+      '0x165c274c67eda2b0d13563124741fffd0ce7d643f4c1c4b59d7e53a83796ae25',
+    isolatedAssetKey: undefined,
+    spool: undefined,
+    spoolReward: undefined,
+  },
   usdc: {
     lendingPoolAddress:
       '0xd3be98bf540f7603eeb550c0c0a19dbfc78822f25158b5fa84ebd9609def415f',
     collateralPoolAddress:
       '0x8f0d529ba179c5b3d508213003eab813aaae31f78226099639b9a69d1aec17af',
-  },
-  sbeth: {
-    lendingPoolAddress:
-      '0x5f08c4f71d56dd3342c452cc70ffc47f2f4180146d821941b0b9c04761bb42e7',
-    collateralPoolAddress:
-      '0xce0549a1cbe952e734f56646988e6b02bbae14667889a60e24d0d03540a6119f',
-  },
-  weth: {
-    lendingPoolAddress:
-      '0xc8fcdff48efc265740ae0b74aae3faccae9ec00034039a113f3339798035108c',
-    collateralPoolAddress:
-      '0xad7ced91ed6e7f2b81805561eee27fa6f3e72fdae561077334c7248583db4dbf',
+    borrowDynamic:
+      '0x77837ecd4f26fac9a410fff594f2c0bd3288904a15492ca77cb8a52684dbb866',
+    interestModel:
+      '0xaae3f179d63009380cbdcb9acb12907afc9c3cb79cc3460be296a9c6d28f3ff3',
+    riskModel:
+      '0x198b24db213bfeb8b3c80ae63dde92e32fd24984d25da8233ff777b851edd574',
+    borrowFeeKey:
+      '0xd37c5316cfe0a5967d14264fa6b423f880518b294a1ee6581ccbb49ccc401fb8',
+    supplyLimitKey:
+      '0x4be9ae54ac4d320f4f9c14cae78cb85c8e0e67791dd9bdba6d2db20614a28a24',
+    borrowLimitKey:
+      '0x6b01093cba95b835181f00e3a2c31ed8dfc8d64fe3db0fb80933a09f66e1ccf1',
+    isolatedAssetKey: undefined,
+    spool: '0x0b5f5f413bd3799e4052c37311966c77f3a4545eb125d2e93e67a68478021918',
+    spoolReward:
+      '0x85ed6ed72ea97c35dbf0cdc7ed6fbc48d8ec15de9b17c74bf4512df8a6d7f166',
   },
   wbtc: {
     lendingPoolAddress:
       '0x65cc08a5aca0a0b8d72e1993ded8d145f06dd102fd0d8f285b92934faed564ab',
     collateralPoolAddress:
       '0x1aa4e5cf743cd797b4eb8bf1e614f80ae2cf556ced426cddaaf190ffcd0e59c3',
+    borrowDynamic:
+      '0x6f97dcf54158a5d08f359a213a41e347bc1e6316414288dc1e1b674dc008742e',
+    interestModel:
+      '0x582b915cca0ffca9576a7cedd505d0fd7cb146e9521ccf10e7453ed93705684d',
+    riskModel:
+      '0x1d0a242bf1682e259112239720da19d3155dd99d70b1f4b3b973eecbab858911',
+    borrowFeeKey:
+      '0x654ab7e8ff6d9ef04da697e1f12ca21eaf72ebb495daf877e0776e65187dcb92',
+    supplyLimitKey:
+      '0xac3b0d17df9f98aa2798c54405cf1d8d5356ef22f76f02d150cbe5195e9f3a36',
+    borrowLimitKey:
+      '0x231e13ba6b1eb26c562f4a125778d3152f9a77e31f124bd6012e234a73012169',
+    isolatedAssetKey: undefined,
+    spool: undefined,
+    spoolReward: undefined,
   },
   wusdc: {
     lendingPoolAddress:
-      '0x9c9077abf7a29eebce41e33addbcd6f5246a5221dd733e56ea0f00ae1b25c9e8',
+      '0x2f4df5e1368fbbdaa5c712d28b837b3d41c2d3872979ccededcdfdac55ff8a93',
     collateralPoolAddress:
-      '0x75aacfb7dcbf92ee0111fc1bf975b12569e4ba632e81ed7ae5ac090d40cd3acb',
+      '0x94cf69158114c5b242d2ee5d0149a335bddf3b9c9a6ba919cca58097a4814980',
+    borrowDynamic:
+      '0x0464d117908b52fc75f7f85322a47caa078ef56f48681bcfdcb630a66f2591e6',
+    interestModel:
+      '0xd72e2b5ba486752939d6dfb86a67b86ce9a60c83cb8fb893caac54a0f112577f',
+    riskModel:
+      '0xb74035de8f70c1531ceb8e2e8c152d6b8db24c8a9fe7bbf6f75dbf7c6700a0a3',
+    borrowFeeKey:
+      '0x76dcf1acbd9951fe3d1a3fe28403fec089ffe53a7c7d6c77e3ea97033a63581a',
+    supplyLimitKey:
+      '0x7b302196907e87c5d5872f2e6f40628d110170f994e0e08bc607bded001958c3',
+    borrowLimitKey:
+      '0x97f1502ce994db0bcb15aac1760d174def9e88e97cd2262eed54521ee2c19f81',
+    isolatedAssetKey: undefined,
+    spool: '0x4ace6648ddc64e646ba47a957c562c32c9599b3bba8f5ac1aadb2ae23a2f8ca0',
+    spoolReward:
+      '0xf4268cc9b9413b9bfe09e8966b8de650494c9e5784bf0930759cfef4904daff8',
+  },
+  weth: {
+    lendingPoolAddress:
+      '0xc8fcdff48efc265740ae0b74aae3faccae9ec00034039a113f3339798035108c',
+    collateralPoolAddress:
+      '0xad7ced91ed6e7f2b81805561eee27fa6f3e72fdae561077334c7248583db4dbf',
+    borrowDynamic:
+      '0xd1578e1d1c9c82eb4c5bf14beece8142a67a683b2647d7276e92984119fc1445',
+    interestModel:
+      '0xa1dc08541cd2cb7cfb4e56272292d5c6a4780e80fd210c58abffae98268b5ed9',
+    riskModel:
+      '0x9f05a25fd33a9e8cf33962126b175d038e184f0ee1b87dc41d4cedbe6abebbe5',
+    borrowFeeKey:
+      '0x29672ba8ab4625b8181d8ed739e5344de22a97d417748c4d1276c7379283d7a3',
+    supplyLimitKey:
+      '0x2b957941bdc9432bbc83ab74dc194b6ebb7c927bc4c6926a5492b5503499e509',
+    borrowLimitKey:
+      '0x51f256d87e51a7ca2b1c482923096f4b6dac6beac89d8ecf4c65b7d5764115d6',
+    isolatedAssetKey: undefined,
+    spool: '0xeec40beccb07c575bebd842eeaabb835f77cd3dab73add433477e57f583a6787',
+    spoolReward:
+      '0x957de68a18d87817de8309b30c1ec269a4d87ae513abbeed86b5619cb9ce1077',
   },
   wusdt: {
     lendingPoolAddress:
       '0xfbc056f126dd35adc1f8fe985e2cedc8010e687e8e851e1c5b99fdf63cd1c879',
     collateralPoolAddress:
       '0x2260cb5b24929dd20a1742f37a61ff3ce4fde5cdb023e2d3ce2e0ce2d90719e3',
+    borrowDynamic:
+      '0xb524030cc8f7cdbf13f1925a0a2b5e77cc52bab73b070f42c5e510f6083da1ba',
+    interestModel:
+      '0x92f93c4431b4c51774d6d964da516af2def18b78f49dbbf519e58449a8ba4659',
+    riskModel:
+      '0xdf89d66988cb506ddeff46f5dfd1d11aaece345e9a05a0c6a18a0788647de2a7',
+    borrowFeeKey:
+      '0xda8f8b3522fc4086eae4ae7ce8844d60aa0dc3eab8ffc91fe93e922a72639b2d',
+    supplyLimitKey:
+      '0xa9cb5ebb90ca6e808a2bd7728cca4a6fa8b565d4deeda96eb23c8322c477c24e',
+    borrowLimitKey:
+      '0xa3278564fc613680a69c10972a0299965bf6e12e9ac171388842fc958de0f90e',
+    isolatedAssetKey: undefined,
+    spool: '0xcb328f7ffa7f9342ed85af3fdb2f22919e1a06dfb2f713c04c73543870d7548f',
+    spoolReward:
+      '0x2c9f934d67a5baa586ceec2cc24163a2f049a6af3d5ba36b84d8ac40f25c4080',
   },
   sui: {
     lendingPoolAddress:
       '0x9c9077abf7a29eebce41e33addbcd6f5246a5221dd733e56ea0f00ae1b25c9e8',
     collateralPoolAddress:
       '0x75aacfb7dcbf92ee0111fc1bf975b12569e4ba632e81ed7ae5ac090d40cd3acb',
+    borrowDynamic:
+      '0xbf68e6159c99dcaf87717385f1143d2891c2d19663bd51f0bc9b6909e4bb7c27',
+    interestModel:
+      '0x0dad9baa89b863c15a0487575de7cc428b01f1aa3998ad7a9e9752d96e83ffa9',
+    riskModel:
+      '0xcd6675864690b5648a6e309f2f02a66914b2b2bd9c31936f4e0f7fc0f792bc86',
+    borrowFeeKey:
+      '0xda5ede87a05c0677b17511c859b22d0a2b0229ee374d5d7a1274cb836b9fe5f8',
+    supplyLimitKey:
+      '0x0602418e66fb7a73fa997077bd66f248ad5b090d43344a14b9f1db598ecc1d47',
+    borrowLimitKey:
+      '0x2b33a7efdcf6a6df24f4d8a356dd52f58d75bc023c3f171d99502d4d008b53f0',
+    isolatedAssetKey: undefined,
+    spool: '0x4f0ba970d3c11db05c8f40c64a15b6a33322db3702d634ced6536960ab6f3ee4',
+    spoolReward:
+      '0x162250ef72393a4ad3d46294c4e1bdfcb03f04c869d390e7efbfc995353a7ee9',
   },
   wapt: {
     lendingPoolAddress:
       '0xca8c14a24e0c32b198eaf479a3317461e3cc339097ce88eaf296a15df8dcfdf5',
     collateralPoolAddress:
       '0xde33f9ac5bb0ed34598da4e64b4983832716ced65f172fbf267bcfe859c4ad9c',
-  },
-  wsol: {
-    lendingPoolAddress:
-      '0x985682c42984cdfb03f9ff7d8923344c2fe096b1ae4b82ea17721af19d22a21f',
-    collateralPoolAddress:
-      '0xdc1cc2c371a043ae8e3c3fe2d013c35f1346960b7dbb4c072982c5b794ed144f',
-  },
-  cetus: {
-    lendingPoolAddress:
-      '0xc09858f60e74a1b671635bec4e8a2c84a0ff313eb87f525fba3258e88c6b6282',
-    collateralPoolAddress:
-      '0xe363967e29b7b9c1245d6d46d63e719de8f90b37e3358c545b55d945ea0b676a',
+    borrowDynamic:
+      '0xadda873fb6bf68e1ba3f2dfaa51cf75d4a1bef73d9627bd36e77d2baecb1f2dc',
+    interestModel:
+      '0xa4a29d07beecea5eb0c59745bb89d7a1380c6f206a7f1ca37046e05db6025c43',
+    riskModel:
+      '0x7ada83b473af30aed50d187de82a0912878b53ade7ac30e11ce23953cf739d84',
+    borrowFeeKey:
+      '0x768735df587c7e0f141dcd035fbbcbf9d2149a7b23888baed4e2baa160fa2eeb',
+    supplyLimitKey: undefined,
+    borrowLimitKey: undefined,
+    isolatedAssetKey: undefined,
+    spool: undefined,
+    spoolReward: undefined,
   },
   afsui: {
     lendingPoolAddress:
       '0x9b942a24ce390b7f5016d34a0217057bf9487b92aa6d7cc9894271dbbe62471a',
     collateralPoolAddress:
       '0xe5e56f5c0e3072760b21f9d49a5cc793f37d736c412a9065c16e1265c74e6341',
+    borrowDynamic:
+      '0x1c76d4df9506154a117bbac0f5e005d8a9c0d9ca60e3fe0c9d080006f6f54e81',
+    interestModel:
+      '0xb155c536b37c9601baaa734ad1dd0ef335b2b597aceb8d3ecee41a43f94dcd70',
+    riskModel:
+      '0x75371b1d04b5bebc0738af548ba64ea658e74f78228ec8014336d8eebb992312',
+    borrowFeeKey:
+      '0xabc6422db2d4ee01635ddaeaa44ba68370eebd785d2c4632515f841ae9bc47d9',
+    supplyLimitKey:
+      '0x61a2054eb37f543c0d774da57f2c9542aad8d79a197f748ac08ef5df6cc47028',
+    borrowLimitKey:
+      '0x4459498a043872cd107ea917493fee0baf2d37a273c7538e1d6581cc61b92af8',
+    isolatedAssetKey: undefined,
+    spool: '0xeedf438abcaa6ce4d9625ffca110920592d5867e4c5637d84ad9f466c4feb800',
+    spoolReward:
+      '0x89255a2f86ed7fbfef35ab8b7be48cc7667015975be2685dd9a55a9a64baf76e',
+  },
+  wsol: {
+    lendingPoolAddress:
+      '0x985682c42984cdfb03f9ff7d8923344c2fe096b1ae4b82ea17721af19d22a21f',
+    collateralPoolAddress:
+      '0xdc1cc2c371a043ae8e3c3fe2d013c35f1346960b7dbb4c072982c5b794ed144f',
+    borrowDynamic:
+      '0xe3f301e16d4f1273ea659dd82c5c3f124ca5a5883a5726c7ec0f77bf43b70895',
+    interestModel:
+      '0xd95affaee077006b8dbb4b108c1b087e95fc6e5143ef0682da345d5b35bc6356',
+    riskModel:
+      '0x8e0da6358073144ec3557400c87f04991ba3a13ca7e0d0a19daed45260b32f16',
+    borrowFeeKey:
+      '0x604bffbc817e8e12db15f2373a9e15b2c7adbc510649cdf2cc62a594af90671c',
+    supplyLimitKey:
+      '0xbd419b536b3f9c9d4adfc20372ca6feedc53cc31798ac860dbfc847bcf05f54b',
+    borrowLimitKey:
+      '0x77d453c51948f32564c810bc73f9ba7abde880657b7f89e1c8a3bc28fa36ee87',
+    isolatedAssetKey: undefined,
+    spool: undefined,
+    spoolReward: undefined,
+  },
+  cetus: {
+    lendingPoolAddress:
+      '0xc09858f60e74a1b671635bec4e8a2c84a0ff313eb87f525fba3258e88c6b6282',
+    collateralPoolAddress:
+      '0xe363967e29b7b9c1245d6d46d63e719de8f90b37e3358c545b55d945ea0b676a',
+    borrowDynamic:
+      '0xcc725fd5d71990cdccc7e16c88a2abde6dbcd0bf6e805ccc1c0cb83a106bbf4e',
+    interestModel:
+      '0x2f1258aab89d04d11834121599ab1317dfecb582b4246f106df399911125845a',
+    riskModel:
+      '0x03fed312dbba624dff5edaf4736891a1c7d864445fd268e7572b42ec7381132e',
+    borrowFeeKey:
+      '0xdf5fb0cc4ebbf5eebfae23dfa5b266f6a58c18a894a13054ae60c0eb6e79c382',
+    supplyLimitKey:
+      '0xa5ea3d4bf663d7bc667e82b40a98923590ff3851b9ea8e7afbc26c588c7007d3',
+    borrowLimitKey:
+      '0xf44218a5f0feb128e6fbe74b91d1e7e9ef859bd23a576ff0de151829e015a157',
+    isolatedAssetKey: undefined,
+    spool: '0xac1bb13bf4472a637c18c2415fb0e3c1227ea2bcf35242e50563c98215bd298e',
+    spoolReward:
+      '0x6835c1224126a45086fc6406adc249e3f30df18d779ca4f4e570e38716a17f3f',
   },
   hasui: {
     lendingPoolAddress:
       '0x7ebc607f6bdeb659fb6506cb91c5cc1d47bb365cfd5d2e637ea765346ec84ed4',
     collateralPoolAddress:
       '0xad9ed40d6486e4c26cec7370dffce8dc4821eb79178250b5938a34ccafd61e6d',
+    borrowDynamic:
+      '0x13ec1220b41c6e0f11dd6113199a2aff8e4cf2223047b5bd06d7a3ed5d23e1d2',
+    interestModel:
+      '0x987c58cbe48096618f4d9d83e0bde2ff638ce4753aba40dab7c302ac3e4b4519',
+    riskModel:
+      '0xe42d8497d423eca0d8df89850c2d77d3644e7f54a2d28f59c315903ea5ec8dec',
+    borrowFeeKey:
+      '0xef885c382d461c4fb14d1f3b3758c380c78a1a4b2a3d2fafe6e8649a60fdd7ab',
+    supplyLimitKey:
+      '0xc7385b1703693cbbc9c97227fe3fd5c91d7afda00e0da69d942c3260d78e45e0',
+    borrowLimitKey:
+      '0x65333e606eead786a999c8267bc9886b0fdbc298a8a8635a48a9c9b8838d9395',
+    isolatedAssetKey: undefined,
+    spool: '0xa6148bc1b623e936d39a952ceb5bea79e8b37228a8f595067bf1852efd3c34aa',
+    spoolReward:
+      '0x6f3563644d3e2ef13176dbf9d865bd93479df60ccbe07b7e66db57f6309f5a66',
   },
   vsui: {
     lendingPoolAddress:
       '0xda9257c0731d8822e8a438ebced13415850d705b779c79958dcf2aeb21fcb43d',
     collateralPoolAddress:
       '0x4435e8b8ec2a04094d863aa52deb6ab6f8f47ed8778f4d9f1b27afc4a6e85f1e',
+    borrowDynamic:
+      '0x8eae703505246f975e83f5af24780e5f1b89ef403d5a80ea15534624d6f1a503',
+    interestModel:
+      '0xaf6a52b5eaaa5af4d9e49d83de0d504c295ae21f3a37560c3f48e0e15a1d4625',
+    riskModel:
+      '0x1e862f27a6bd47c3041159a5cf392f549485c6605ed9aa937f16ecc951e82e65',
+    borrowFeeKey:
+      '0x5230de0f41a5e4c05b3d1187a90a9eeab491cec97b08b71512d9785e8af36aa6',
+    supplyLimitKey:
+      '0x1d40e34d1f365ec431fff020bd75c16b14b340b3ed6c139803cc15c2384621b2',
+    borrowLimitKey:
+      '0x4eb206b4417642cfc1b02f80bb5f5e366af2af2f9fb4ea4f4e898ae82367f8a0',
+    isolatedAssetKey: undefined,
+    spool: '0x69ce8e537e750a95381e6040794afa5ab1758353a1a2e1de7760391b01f91670',
+    spoolReward:
+      '0xbca914adce058ad0902c7f3cfcd698392a475f00dcfdc3f76001d0370b98777a',
   },
   sca: {
     lendingPoolAddress:
       '0x6fc7d4211fc7018b6c75e7b908b88f2e0536443239804a3d32af547637bd28d7',
     collateralPoolAddress:
       '0xff677a5d9e9dc8f08f0a8681ebfc7481d1c7d57bc441f2881974adcdd7b13c31',
-  },
-  fud: {
-    lendingPoolAddress:
-      '0x14367ddca30e2860cb89ed4eaca20c7ece260c5d59dd9990d2c85a8321326acb',
+    borrowDynamic:
+      '0x4e24f52edd739dab59ca4c6353ca430b7ce57e7f333abd0957958570a7cd09ca',
+    interestModel:
+      '0xbdcd48cf5b1a814911dc2d5c72d393a980c87820199fe5d799289ce94f4c47df',
+    riskModel:
+      '0xc437c24b67b8e2676907700fa395af337ad6463d2c0b4f4fa2e9276414026089',
+    borrowFeeKey:
+      '0xee55ba0f9800a62d9e7aef667f87e658258f41814d2c9fa02e25590671b4e5ad',
+    supplyLimitKey:
+      '0x8dd938856b972a10ea27ecab2af7ed78e48fc5f6ccedaf2b2119959f747dc2e3',
+    borrowLimitKey:
+      '0x04c7de61c5b42972f9bf6a8b1848e5fea2d037ee8deba81741ecd4a70aa80d30',
+    isolatedAssetKey: undefined,
+    spool: undefined,
+    spoolReward: undefined,
   },
   deep: {
     lendingPoolAddress:
       '0xf4a67ffb43da1e1c61c049f188f19463ea8dbbf2d5ef4722d6df854ff1b1cc03',
+    collateralPoolAddress: undefined,
+    borrowDynamic:
+      '0x95e00d7466f97a100e70f08bd37788dc49335796f6f49fab996d40dd0681c6d3',
+    interestModel:
+      '0x4143c298506a332d92ea8a995e6f3991ee3215f58f6fc6441752835d275b9a69',
+    riskModel: undefined,
+    borrowFeeKey:
+      '0xb14ee43f4ad2a2c40bac8c4406a401690e93c982e289cf3802fedf74a159cab2',
+    supplyLimitKey:
+      '0x599528fdfdc253e90dfd0acf4f4a166b391e2aac1ca6528abbff63225b548fee',
+    borrowLimitKey:
+      '0xf4217e8ef9d9c32e8992092e910a77535a8124c19b8a762a673f227f5f765a4e',
+    isolatedAssetKey:
+      '0x208d3a24ba369dcfc8f0387333d1512b98199eb150d2f2a69359ff708cf761e3',
+    spool: undefined,
+    spoolReward: undefined,
+  },
+  fud: {
+    lendingPoolAddress:
+      '0xefed2cbe76b344792ac724523c8b2236740d1cea2100d46a0ed0dc760c7f4231',
+    collateralPoolAddress: undefined,
+    borrowDynamic:
+      '0x14367ddca30e2860cb89ed4eaca20c7ece260c5d59dd9990d2c85a8321326acb',
+    interestModel:
+      '0x2600ac100ef154eb2329ffd3aad47aca308ff9f9348de3e8e94aaeb906ec2303',
+    riskModel: undefined,
+    borrowFeeKey:
+      '0xa87e8b26e07ff35ac9fb57adcc779be2883080fc7d12de2d9e7e16d8d8d5e529',
+    supplyLimitKey:
+      '0xf98419aecc37a3c5de716f8ec590f8991a5be34da72ce1a2da09531ff45adf7d',
+    borrowLimitKey:
+      '0x3d928a001c453c50004baa54e14b0a0e1b0907d9c613dfd76064fd7ed4e8beb8',
+    isolatedAssetKey:
+      '0xfcb533e9e4e31f9c9f32d6cbf7fbb3425f1d60474e229a363a2dc7f835d587e2',
+    spool: undefined,
+    spoolReward: undefined,
   },
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -97,6 +97,10 @@ export const queryKeys = {
       'getAllCoinBalances',
       { owner },
     ],
+
+    getNormalizedMoveFunction: (target?: string) => {
+      return ['rpc', 'getNormalizedMoveCall', target];
+    },
   },
   oracle: {
     getPythLatestPriceFeeds: () => ['oracle', 'getPythPriceIds'],

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -34,11 +34,11 @@ export const queryKeys = {
         typeArgs: !typeArgs ? undefined : JSON.stringify(typeArgs),
       },
     ],
-    getObject: (
-      objectId?: string,
-      walletAddress?: string,
-      options?: SuiObjectDataOptions
-    ) => ['rpc', 'getObject', { walletAddress, options, objectId }],
+    getObject: (objectId?: string, options?: SuiObjectDataOptions) => [
+      'rpc',
+      'getObject',
+      { options, objectId },
+    ],
     getObjects: (
       objectIds?: string[],
       walletAddress?: string,

--- a/src/constants/tokenBucket.ts
+++ b/src/constants/tokenBucket.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_TOKENS_PER_INTERVAL = 50;
+export const DEFAULT_TOKENS_PER_INTERVAL = 10;
 export const DEFAULT_INTERVAL_IN_MS = 250;

--- a/src/constants/tokenBucket.ts
+++ b/src/constants/tokenBucket.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_TOKENS_PER_INTERVAL = 10;
-export const DEFAULT_INTERVAL_IN_MS = 50;
+export const DEFAULT_TOKENS_PER_INTERVAL = 50;
+export const DEFAULT_INTERVAL_IN_MS = 250;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './constants';
 export * from './models';
 export type * from './types';
+export * from './utils/tokenBucket';

--- a/src/models/scallopBuilder.ts
+++ b/src/models/scallopBuilder.ts
@@ -222,52 +222,54 @@ export class ScallopBuilder {
     )) as SuiTransactionBlockResponse;
   }
 
-  public async moveCall(
+  public moveCall(
     txb: ScallopTxBlock | SuiKitTxBlock,
     target: string,
     args?: (SuiTxArg | SuiVecTxArg | SuiObjectArg | SuiAmountsArg)[],
     typeArgs?: string[]
   ) {
-    const resolvedQueryTarget =
-      await this.cache.queryGetNormalizedMoveFunction(target);
-    if (!resolvedQueryTarget) throw new Error('Invalid query target');
+    // Disable for now
+    // const resolvedQueryTarget =
+    //   await this.cache.queryGetNormalizedMoveFunction(target);
+    // if (!resolvedQueryTarget) throw new Error('Invalid query target');
 
-    const { parameters } = resolvedQueryTarget;
-    try {
-      // we can try resolve the args first
-      const resolvedArgs = await Promise.all(
-        (args ?? []).map(async (arg, idx) => {
-          if (typeof arg !== 'string') return arg;
+    // const { parameters } = resolvedQueryTarget;
+    // try {
+    //   // we can try resolve the args first
+    //   const resolvedArgs = await Promise.all(
+    //     (args ?? []).map(async (arg, idx) => {
+    //       if (typeof arg !== 'string') return arg;
 
-          const cachedData = (await this.cache.queryGetObject(arg))?.data;
-          if (!cachedData) return arg;
+    //       const cachedData = (await this.cache.queryGetObject(arg))?.data;
+    //       if (!cachedData) return arg;
 
-          const owner = cachedData.owner;
-          if (!owner || typeof owner !== 'object' || !('Shared' in owner))
-            return {
-              objectId: cachedData.objectId,
-              version: cachedData.version,
-              digest: cachedData.digest,
-            };
+    //       const owner = cachedData.owner;
+    //       if (!owner || typeof owner !== 'object' || !('Shared' in owner))
+    //         return {
+    //           objectId: cachedData.objectId,
+    //           version: cachedData.version,
+    //           digest: cachedData.digest,
+    //         };
 
-          const parameter = parameters[idx];
-          if (
-            typeof parameter !== 'object' ||
-            !('MutableReference' in parameter || 'Reference' in parameter)
-          )
-            return arg;
+    //       const parameter = parameters[idx];
+    //       if (
+    //         typeof parameter !== 'object' ||
+    //         !('MutableReference' in parameter || 'Reference' in parameter)
+    //       )
+    //         return arg;
 
-          return {
-            objectId: cachedData.objectId,
-            initialSharedVersion: owner.Shared.initial_shared_version,
-            mutable: 'MutableReference' in parameter,
-          };
-        })
-      );
-      return txb.moveCall(target, resolvedArgs, typeArgs);
-    } catch (e: any) {
-      console.error(e.message);
-      return txb.moveCall(target, args, typeArgs);
-    }
+    //       return {
+    //         objectId: cachedData.objectId,
+    //         initialSharedVersion: owner.Shared.initial_shared_version,
+    //         mutable: 'MutableReference' in parameter,
+    //       };
+    //     })
+    //   );
+    //   return txb.moveCall(target, resolvedArgs, typeArgs);
+    // } catch (e: any) {
+    //   console.error(e.message);
+    //   return txb.moveCall(target, args, typeArgs);
+    // }
+    return txb.moveCall(target, args, typeArgs);
   }
 }

--- a/src/models/scallopCache.ts
+++ b/src/models/scallopCache.ts
@@ -231,6 +231,7 @@ export class ScallopCache {
    * @returns Promise<PaginatedObjectsResponse>
    */
   public async queryGetOwnedObjects(input: GetOwnedObjectsParams) {
+    // TODO: This query need its own separate rate limiter (as owned objects can theoretically be infinite), need a better way to handle this
     return this.queryClient.fetchQuery({
       retry: this.retryFn,
       retryDelay: 1000,

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -965,6 +965,7 @@ export class ScallopClient {
     const rewardCoinsCollection: Record<string, TransactionResult[]> = {};
     const obligationAccount =
       await this.query.getObligationAccount(obligationId);
+    if (!obligationAccount) throw new Error('Obligation not found');
     const rewardCoinNames = Object.values(obligationAccount.borrowIncentives)
       .flatMap(({ rewards }) =>
         rewards.filter(({ availableClaimAmount }) => availableClaimAmount > 0)

--- a/src/models/scallopClient.ts
+++ b/src/models/scallopClient.ts
@@ -232,7 +232,7 @@ export class ScallopClient {
     sign: S = true as S
   ): Promise<ScallopClientFnReturnType<S>> {
     const txBlock = this.builder.createTxBlock();
-    txBlock.openObligationEntry();
+    await txBlock.openObligationEntry();
     if (sign) {
       return (await this.suiKit.signAndSendTxn(
         txBlock
@@ -283,9 +283,10 @@ export class ScallopClient {
         specificObligationId
       );
     } else {
-      const [obligation, obligationKey, hotPotato] = txBlock.openObligation();
+      const [obligation, obligationKey, hotPotato] =
+        await txBlock.openObligation();
       await txBlock.addCollateralQuick(amount, collateralCoinName, obligation);
-      txBlock.returnObligation(obligation, hotPotato);
+      await txBlock.returnObligation(obligation, hotPotato);
       txBlock.transferObjects([obligationKey], sender);
     }
 
@@ -425,7 +426,7 @@ export class ScallopClient {
         targetStakeAccount
       );
     } else {
-      const account = txBlock.createStakeAccount(stakeMarketCoinName);
+      const account = await txBlock.createStakeAccount(stakeMarketCoinName);
       await txBlock.stakeQuick(marketCoin, stakeMarketCoinName, account);
       txBlock.transferObjects([account], sender);
     }
@@ -611,8 +612,12 @@ export class ScallopClient {
     const txBlock = this.builder.createTxBlock();
     const sender = walletAddress ?? this.walletAddress;
     txBlock.setSender(sender);
-    const [coin, loan] = txBlock.borrowFlashLoan(amount, poolCoinName);
-    txBlock.repayFlashLoan(await callback(txBlock, coin), loan, poolCoinName);
+    const [coin, loan] = await txBlock.borrowFlashLoan(amount, poolCoinName);
+    await txBlock.repayFlashLoan(
+      await callback(txBlock, coin),
+      loan,
+      poolCoinName
+    );
 
     if (sign) {
       return (await this.suiKit.signAndSendTxn(
@@ -649,7 +654,7 @@ export class ScallopClient {
     const sender = walletAddress ?? this.walletAddress;
     txBlock.setSender(sender);
 
-    const stakeAccount = txBlock.createStakeAccount(marketCoinName);
+    const stakeAccount = await txBlock.createStakeAccount(marketCoinName);
     txBlock.transferObjects([stakeAccount], sender);
 
     if (sign) {
@@ -699,7 +704,7 @@ export class ScallopClient {
     if (targetStakeAccount) {
       await txBlock.stakeQuick(amount, stakeMarketCoinName, targetStakeAccount);
     } else {
-      const account = txBlock.createStakeAccount(stakeMarketCoinName);
+      const account = await txBlock.createStakeAccount(stakeMarketCoinName);
       await txBlock.stakeQuick(amount, stakeMarketCoinName, account);
       txBlock.transferObjects([account], sender);
     }
@@ -814,7 +819,7 @@ export class ScallopClient {
       this.utils.parseCoinName<SupportStakeCoins>(stakeMarketCoinName);
 
     if (stakeMarketCoin) {
-      const coin = txBlock.withdraw(stakeMarketCoin, stakeCoinName);
+      const coin = await txBlock.withdraw(stakeMarketCoin, stakeCoinName);
       await this.utils.mergeSimilarCoins(
         txBlock,
         coin,
@@ -1048,7 +1053,7 @@ export class ScallopClient {
         // if market coin found, mint sCoin
         if (toDestroyMarketCoin) {
           // mint new sCoin
-          const sCoin = txBlock.mintSCoin(
+          const sCoin = await txBlock.mintSCoin(
             sCoinName as SupportSCoin,
             toDestroyMarketCoin
           );

--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -14,7 +14,7 @@ import {
   getStakeRewardPool,
   getPythPrice,
   getMarketPools,
-  getMarketPool,
+  // getMarketPool,
   getMarketCollaterals,
   getMarketCollateral,
   getSpools,
@@ -41,13 +41,15 @@ import {
   getBorrowIncentivePools,
   getBorrowLimit,
   getIsolatedAssets,
-  isIsolatedAsset,
+  // isIsolatedAsset,
   getSupplyLimit,
   getSCoinAmount,
   getSCoinAmounts,
   getSCoinSwapRate,
   getSCoinTotalSupply,
   getAllCoinPrices,
+  getAllAddresses,
+  isIsolatedAsset,
 } from '../queries';
 import {
   ScallopQueryParams,
@@ -188,6 +190,7 @@ export class ScallopQuery {
   /* ==================== Core Query Methods ==================== */
 
   /**
+   * @deprecated use getMarketPools
    * Query market data.
    * @param indexer - Whether to use indexer.
    * @return Market data.
@@ -211,7 +214,7 @@ export class ScallopQuery {
    * @return Market pools data.
    */
   public async getMarketPools(
-    poolCoinNames?: SupportPoolCoins[],
+    poolCoinNames: SupportPoolCoins[] = [...SUPPORT_POOLS],
     args?: {
       coinPrices?: CoinPrices;
       indexer?: boolean;
@@ -235,18 +238,19 @@ export class ScallopQuery {
   public async getMarketPool(
     poolCoinName: SupportPoolCoins,
     args?: {
-      marketObject?: SuiObjectData | null;
       coinPrice?: number;
       indexer?: boolean;
     }
   ) {
-    return await getMarketPool(
-      this,
-      poolCoinName,
-      args?.indexer,
-      args?.marketObject,
-      args?.coinPrice
-    );
+    const marketPools = await this.getMarketPools(undefined, args);
+    return marketPools.pools[poolCoinName];
+    // return await getMarketPool(
+    //   this,
+    //   poolCoinName,
+    //   args?.indexer,
+    //   args?.marketObject,
+    //   args?.coinPrice
+    // );
   }
 
   /**
@@ -812,7 +816,7 @@ export class ScallopQuery {
    * Get list of isolated assets
    */
   public async getIsolatedAssets() {
-    return await getIsolatedAssets(this.address);
+    return await getIsolatedAssets(this);
   }
 
   /**
@@ -840,5 +844,13 @@ export class ScallopQuery {
     coinPrices?: CoinPrices;
   }) {
     return getAllCoinPrices(this, args?.marketPools, args?.coinPrices);
+  }
+
+  /**
+   * Query all address (lending pool, collateral pool, borrow dynamics, interest models) of all pool
+   * @returns
+   */
+  public async getPoolAddresses() {
+    return getAllAddresses(this);
   }
 }

--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -25,7 +25,6 @@ import {
   getLendings,
   getLending,
   getObligationAccounts,
-  getObligationAccount,
   getTotalValueLocked,
   queryVeScaKeyIdFromReferralBindings,
   getBindedObligationId,
@@ -615,7 +614,7 @@ export class ScallopQuery {
    */
   public async getObligationAccounts(
     ownerAddress: string = this.walletAddress,
-    args?: { indexer: boolean }
+    args?: { indexer?: boolean }
   ) {
     return await getObligationAccounts(this, ownerAddress, args?.indexer);
   }
@@ -636,12 +635,16 @@ export class ScallopQuery {
     ownerAddress: string = this.walletAddress,
     args?: { indexer?: boolean }
   ) {
-    return await getObligationAccount(
-      this,
-      obligationId,
-      ownerAddress,
-      args?.indexer
+    const results = await this.getObligationAccounts(ownerAddress, args);
+    return Object.values(results).find(
+      (obligation) => obligation?.obligationId === obligationId
     );
+    // return await getObligationAccount(
+    //   this,
+    //   obligationId,
+    //   ownerAddress,
+    //   args?.indexer
+    // );
   }
 
   /**

--- a/src/models/scallopQuery.ts
+++ b/src/models/scallopQuery.ts
@@ -14,11 +14,9 @@ import {
   getStakeRewardPool,
   getPythPrice,
   getMarketPools,
-  // getMarketPool,
   getMarketCollaterals,
   getMarketCollateral,
   getSpools,
-  getSpool,
   queryBorrowIncentiveAccounts,
   getCoinAmounts,
   getCoinAmount,
@@ -422,13 +420,8 @@ export class ScallopQuery {
       indexer?: boolean;
     }
   ) {
-    return await getSpool(
-      this,
-      stakeMarketCoinName,
-      args?.indexer,
-      args?.marketPool,
-      args?.coinPrices
-    );
+    const spools = await this.getSpools(undefined, args);
+    return spools[stakeMarketCoinName];
   }
 
   /**

--- a/src/queries/borrowIncentiveQuery.ts
+++ b/src/queries/borrowIncentiveQuery.ts
@@ -65,7 +65,7 @@ export const getBorrowIncentivePools = async (
   const borrowIncentivePools: BorrowIncentivePools = {};
   marketPools =
     marketPools ??
-    (await query.getMarketPools(undefined, { coinPrices, indexer }));
+    (await query.getMarketPools(undefined, { coinPrices, indexer })).pools;
   coinPrices = coinPrices ?? (await query.getAllCoinPrices({ marketPools }));
 
   if (indexer) {

--- a/src/queries/coreQuery.ts
+++ b/src/queries/coreQuery.ts
@@ -3,14 +3,15 @@ import {
   SUPPORT_POOLS,
   PROTOCOL_OBJECT_ID,
   SUPPORT_COLLATERALS,
-  BORROW_FEE_PROTOCOL_ID,
   FlashLoanFeeObjectMap,
+  POOL_ADDRESSES,
 } from '../constants';
 import {
   parseOriginMarketPoolData,
   calculateMarketPoolData,
   parseOriginMarketCollateralData,
   calculateMarketCollateralData,
+  parseObjectAs,
 } from '../utils';
 import type { SuiObjectResponse, SuiObjectData } from '@mysten/sui/client';
 import type { SuiObjectArg } from '@scallop-io/sui-kit';
@@ -28,21 +29,27 @@ import {
   ObligationQueryInterface,
   Obligation,
   InterestModel,
-  BorrowIndex,
   BalanceSheet,
   RiskModel,
   CollateralStat,
   SupportMarketCoins,
   OptionalKeys,
   CoinPrices,
+  OriginMarketPoolData,
+  BorrowFee,
+  BorrowDynamic,
+  OriginMarketCollateralData,
 } from '../types';
 import BigNumber from 'bignumber.js';
 import { getSupplyLimit } from './supplyLimitQuery';
 import { isIsolatedAsset } from './isolatedAssetQuery';
 import { getBorrowLimit } from './borrowLimitQuery';
+import { queryMultipleObjects } from './objectsQuery';
 
 /**
  * Query market data.
+ *
+ * @deprecated Use query market pools
  *
  * @description
  * Use inspectTxn call to obtain the data provided in the scallop contract query module.
@@ -126,25 +133,15 @@ export const queryMarket = async (
       highKink: pool.highKink,
       midKink: pool.midKink,
       minBorrowAmount: pool.minBorrowAmount,
+      isIsolated: await isIsolatedAsset(query.utils, poolCoinName),
+      supplyLimit: (await getSupplyLimit(query.utils, poolCoinName)) ?? '0',
+      borrowLimit: (await getBorrowLimit(query.utils, poolCoinName)) ?? '0',
     });
 
     const calculatedMarketPoolData = calculateMarketPoolData(
       query.utils,
       parsedMarketPoolData
     );
-
-    const coinDecimal = query.utils.getCoinDecimal(poolCoinName);
-    const maxSupplyCoin = BigNumber(
-      (await getSupplyLimit(query.utils, poolCoinName)) ?? '0'
-    )
-      .shiftedBy(-coinDecimal)
-      .toNumber();
-
-    const maxBorrowCoin = BigNumber(
-      (await getBorrowLimit(query.utils, poolCoinName)) ?? '0'
-    )
-      .shiftedBy(-coinDecimal)
-      .toNumber();
 
     pools[poolCoinName] = {
       coinName: poolCoinName,
@@ -155,7 +152,6 @@ export const queryMarket = async (
         query.utils.parseMarketCoinName(poolCoinName)
       ),
       coinWrappedType: query.utils.getCoinWrappedType(poolCoinName),
-      coinDecimal,
       coinPrice: coinPrice,
       highKink: parsedMarketPoolData.highKink,
       midKink: parsedMarketPoolData.midKink,
@@ -164,10 +160,6 @@ export const queryMarket = async (
       borrowFee: parsedMarketPoolData.borrowFee,
       marketCoinSupplyAmount: parsedMarketPoolData.marketCoinSupplyAmount,
       minBorrowAmount: parsedMarketPoolData.minBorrowAmount,
-      isIsolated: await isIsolatedAsset(query.utils, poolCoinName),
-      // isIsolated: false,
-      maxSupplyCoin,
-      maxBorrowCoin,
       ...calculatedMarketPoolData,
     };
   }
@@ -188,10 +180,11 @@ export const queryMarket = async (
       collateralFactor: collateral.collateralFactor,
       liquidationFactor: collateral.liquidationFactor,
       liquidationDiscount: collateral.liquidationDiscount,
-      liquidationPanelty: collateral.liquidationPanelty,
+      liquidationPenalty: collateral.liquidationPanelty,
       liquidationReserveFactor: collateral.liquidationReserveFactor,
       maxCollateralAmount: collateral.maxCollateralAmount,
       totalCollateralAmount: collateral.totalCollateralAmount,
+      isIsolated: await isIsolatedAsset(query.utils, collateralCoinName),
     });
 
     const calculatedMarketCollateralData = calculateMarketCollateralData(
@@ -205,15 +198,14 @@ export const queryMarket = async (
       coinType: coinType,
       marketCoinType: query.utils.parseMarketCoinType(collateralCoinName),
       coinWrappedType: query.utils.getCoinWrappedType(collateralCoinName),
-      coinDecimal: query.utils.getCoinDecimal(collateralCoinName),
       coinPrice: coinPrice,
       collateralFactor: parsedMarketCollateralData.collateralFactor,
       liquidationFactor: parsedMarketCollateralData.liquidationFactor,
       liquidationDiscount: parsedMarketCollateralData.liquidationDiscount,
-      liquidationPanelty: parsedMarketCollateralData.liquidationPanelty,
+      liquidationPenalty: parsedMarketCollateralData.liquidationPenalty,
       liquidationReserveFactor:
         parsedMarketCollateralData.liquidationReserveFactor,
-      isIsolated: await isIsolatedAsset(query.utils, collateralCoinName),
+
       ...calculatedMarketCollateralData,
     };
   }
@@ -223,6 +215,135 @@ export const queryMarket = async (
     collaterals,
     // data: marketData,
   } as Market;
+};
+
+const queryRequiredMarketObjects = async (
+  query: ScallopQuery,
+  poolCoinNames: SupportPoolCoins[]
+) => {
+  // Prepare all tasks for querying each object type
+  const tasks = poolCoinNames.map((t) => ({
+    poolCoinName: t,
+    balanceSheet: POOL_ADDRESSES[t]?.lendingPoolAddress,
+    collateralStat: POOL_ADDRESSES[t]?.collateralPoolAddress,
+    borrowDynamic: POOL_ADDRESSES[t]?.borrowDynamic,
+    interestModel: POOL_ADDRESSES[t]?.interestModel,
+    riskModel: POOL_ADDRESSES[t]?.riskModel,
+    borrowFeeKey: POOL_ADDRESSES[t]?.borrowFeeKey,
+    supplyLimitKey: POOL_ADDRESSES[t]?.supplyLimitKey,
+    borrowLimitKey: POOL_ADDRESSES[t]?.borrowLimitKey,
+    isolatedAssetKey: POOL_ADDRESSES[t]?.isolatedAssetKey,
+  }));
+
+  // Query all objects for each key in parallel
+  const [
+    balanceSheetObjects,
+    collateralStatObjects,
+    borrowDynamicObjects,
+    interestModelObjects,
+    riskModelObjects,
+    borrowFeeObjects,
+    supplyLimitObjects,
+    borrowLimitObjects,
+    isolatedAssetObjects,
+  ] = await Promise.all([
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.balanceSheet).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.collateralStat).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.borrowDynamic).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.interestModel).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.riskModel).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.borrowFeeKey).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.supplyLimitKey).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.borrowLimitKey).filter((t): t is string => !!t)
+    ),
+    queryMultipleObjects(
+      query.cache,
+      tasks.map((task) => task.isolatedAssetKey).filter((t): t is string => !!t)
+    ),
+  ]);
+
+  // Map the results back to poolCoinNames
+  const mapObjects = (
+    tasks: { poolCoinName: string; [key: string]: string | undefined }[],
+    fetchedObjects: SuiObjectData[]
+  ) => {
+    const resultMap: Record<string, SuiObjectData> = {};
+    let fetchedIndex = 0;
+
+    for (const task of tasks) {
+      const key = task[Object.keys(task)[1]]; // current object key being queried
+      if (key) {
+        resultMap[task.poolCoinName] = fetchedObjects[fetchedIndex];
+        fetchedIndex++;
+      }
+    }
+    return resultMap;
+  };
+
+  const balanceSheetMap = mapObjects(tasks, balanceSheetObjects);
+  const collateralStatMap = mapObjects(tasks, collateralStatObjects);
+  const borrowDynamicMap = mapObjects(tasks, borrowDynamicObjects);
+  const interestModelMap = mapObjects(tasks, interestModelObjects);
+  const riskModelMap = mapObjects(tasks, riskModelObjects);
+  const borrowFeeMap = mapObjects(tasks, borrowFeeObjects);
+  const supplyLimitMap = mapObjects(tasks, supplyLimitObjects);
+  const borrowLimitMap = mapObjects(tasks, borrowLimitObjects);
+  const isolatedAssetMap = mapObjects(tasks, isolatedAssetObjects);
+
+  // Construct the final requiredObjects result
+  return poolCoinNames.reduce(
+    (acc, name) => {
+      acc[name] = {
+        balanceSheet: balanceSheetMap[name],
+        collateralStat: collateralStatMap[name],
+        borrowDynamic: borrowDynamicMap[name],
+        interestModel: interestModelMap[name],
+        riskModel: riskModelMap[name],
+        borrowFeeKey: borrowFeeMap[name],
+        supplyLimitKey: supplyLimitMap[name],
+        borrowLimitKey: borrowLimitMap[name],
+        isolatedAssetKey: isolatedAssetMap[name],
+      };
+      return acc;
+    },
+    {} as Record<
+      SupportPoolCoins,
+      {
+        balanceSheet: SuiObjectData;
+        collateralStat?: SuiObjectData;
+        riskModel?: SuiObjectData;
+        borrowDynamic: SuiObjectData;
+        interestModel: SuiObjectData;
+        borrowFeeKey: SuiObjectData;
+        supplyLimitKey: SuiObjectData;
+        borrowLimitKey: SuiObjectData;
+        isolatedAssetKey: SuiObjectData;
+      }
+    >
+  );
 };
 
 /**
@@ -239,53 +360,172 @@ export const queryMarket = async (
  */
 export const getMarketPools = async (
   query: ScallopQuery,
-  poolCoinNames: SupportPoolCoins[] = [...SUPPORT_POOLS],
+  poolCoinNames: SupportPoolCoins[],
   indexer: boolean = false,
   coinPrices?: CoinPrices
-) => {
-  const marketId = query.address.get('core.market');
-  const marketObjectResponse = await query.cache.queryGetObject(marketId, {
-    showContent: true,
-  });
+): Promise<{
+  pools: MarketPools;
+  collaterals: MarketCollaterals;
+}> => {
   coinPrices = coinPrices ?? (await query.utils.getCoinPrices());
 
-  const marketPools: MarketPools = {};
+  const pools: MarketPools = {};
+  const collaterals: MarketCollaterals = {};
 
   if (indexer) {
-    const marketPoolsIndexer = await query.indexer.getMarketPools();
+    // const marketPoolsIndexer = await query.indexer.getMarketPools();
 
-    const updateMarketPool = (marketPool: MarketPool) => {
-      if (!poolCoinNames.includes(marketPool.coinName)) return;
-      marketPool.coinPrice =
-        coinPrices[marketPool.coinName] ?? marketPool.coinPrice;
-      marketPool.coinWrappedType = query.utils.getCoinWrappedType(
-        marketPool.coinName
-      );
-      marketPools[marketPool.coinName] = marketPool;
+    // const updateMarketPool = (marketPool: MarketPool) => {
+    //   if (!poolCoinNames.includes(marketPool.coinName)) return;
+    //   marketPool.coinPrice =
+    //     coinPrices[marketPool.coinName] ?? marketPool.coinPrice;
+    //   marketPool.coinWrappedType = query.utils.getCoinWrappedType(
+    //     marketPool.coinName
+    //   );
+    //   pools[marketPool.coinName] = marketPool;
+    // };
+
+    // Object.values(marketPoolsIndexer).forEach(updateMarketPool);
+
+    // return pools;
+    const marketIndexer = await query.indexer.getMarket();
+
+    const updatePools = (item: MarketPool) => {
+      item.coinPrice = coinPrices[item.coinName] ?? item.coinPrice;
+      item.coinWrappedType = query.utils.getCoinWrappedType(item.coinName);
+      pools[item.coinName] = item;
     };
 
-    Object.values(marketPoolsIndexer).forEach(updateMarketPool);
+    const updateCollaterals = (item: MarketCollateral) => {
+      item.coinPrice = coinPrices[item.coinName] ?? item.coinPrice;
+      item.coinWrappedType = query.utils.getCoinWrappedType(item.coinName);
+      collaterals[item.coinName] = item;
+    };
 
-    return marketPools;
+    Object.values(marketIndexer.pools).forEach(updatePools);
+    Object.values(marketIndexer.collaterals).forEach(updateCollaterals);
+
+    return {
+      pools,
+      collaterals,
+    };
   }
+
+  const requiredObjects = await queryRequiredMarketObjects(
+    query,
+    poolCoinNames
+  );
 
   await Promise.allSettled(
     poolCoinNames.map(async (poolCoinName) => {
-      const marketPool = await getMarketPool(
-        query,
-        poolCoinName,
-        indexer,
-        marketObjectResponse?.data,
-        coinPrices?.[poolCoinName]
-      );
-
-      if (marketPool) {
-        marketPools[poolCoinName] = marketPool;
+      try {
+        const result = await getMarketPool(
+          query,
+          poolCoinName,
+          indexer,
+          coinPrices?.[poolCoinName] ?? 0,
+          requiredObjects[poolCoinName]
+        );
+        if (result?.marketPool) {
+          pools[poolCoinName] = result?.marketPool;
+        }
+        if (result?.collateral) {
+          collaterals[poolCoinName as SupportCollateralCoins] =
+            result.collateral;
+        }
+      } catch (e) {
+        console.error(e);
       }
     })
   );
 
-  return marketPools;
+  return {
+    pools,
+    collaterals,
+  };
+};
+
+const parseMarketPoolObjects = ({
+  balanceSheet,
+  borrowDynamic,
+  collateralStat,
+  interestModel,
+  riskModel,
+  borrowFeeKey,
+  supplyLimitKey,
+  borrowLimitKey,
+  isolatedAssetKey,
+}: {
+  balanceSheet: SuiObjectData;
+  borrowDynamic: SuiObjectData;
+  collateralStat?: SuiObjectData;
+  interestModel: SuiObjectData;
+  riskModel?: SuiObjectData;
+  borrowFeeKey: SuiObjectData;
+  supplyLimitKey?: SuiObjectData;
+  borrowLimitKey?: SuiObjectData;
+  isolatedAssetKey: SuiObjectData;
+}): OriginMarketPoolData & {
+  parsedOriginMarketCollateral?: OriginMarketCollateralData;
+} => {
+  const _balanceSheet = parseObjectAs<BalanceSheet>(balanceSheet);
+  const _interestModel = parseObjectAs<InterestModel>(interestModel);
+  const _borrowDynamic = parseObjectAs<BorrowDynamic>(borrowDynamic);
+  const _borrowFee = parseObjectAs<BorrowFee>(borrowFeeKey);
+  const _supplyLimit = supplyLimitKey
+    ? parseObjectAs<string>(supplyLimitKey)
+    : '0';
+  const _borrowLimit = borrowLimitKey
+    ? parseObjectAs<string>(borrowLimitKey)
+    : '0';
+  const _riskModel = riskModel
+    ? parseObjectAs<RiskModel>(riskModel)
+    : undefined;
+  const _collateralStat = collateralStat
+    ? parseObjectAs<CollateralStat>(collateralStat)
+    : undefined;
+
+  const parsedOriginMarketCollateral =
+    _riskModel && _collateralStat
+      ? {
+          type: _interestModel.type.fields,
+          isIsolated: !!isolatedAssetKey,
+          collateralFactor: _riskModel.collateral_factor.fields,
+          liquidationFactor: _riskModel.liquidation_factor.fields,
+          liquidationPenalty: _riskModel.liquidation_penalty.fields,
+          liquidationDiscount: _riskModel.liquidation_discount.fields,
+          liquidationReserveFactor:
+            _riskModel.liquidation_revenue_factor.fields,
+          maxCollateralAmount: _riskModel.max_collateral_amount,
+          totalCollateralAmount: _collateralStat.amount,
+        }
+      : undefined;
+
+  return {
+    type: _interestModel.type.fields,
+    maxBorrowRate: _interestModel.max_borrow_rate.fields,
+    interestRate: _borrowDynamic.interest_rate.fields,
+    interestRateScale: _borrowDynamic.interest_rate_scale,
+    borrowIndex: _borrowDynamic.borrow_index,
+    lastUpdated: _borrowDynamic.last_updated,
+    cash: _balanceSheet.cash,
+    debt: _balanceSheet.debt,
+    marketCoinSupply: _balanceSheet.market_coin_supply,
+    reserve: _balanceSheet.revenue,
+    reserveFactor: _interestModel.revenue_factor.fields,
+    borrowWeight: _interestModel.borrow_weight.fields,
+    borrowFeeRate: _borrowFee,
+    baseBorrowRatePerSec: _interestModel.base_borrow_rate_per_sec.fields,
+    borrowRateOnHighKink: _interestModel.borrow_rate_on_high_kink.fields,
+    borrowRateOnMidKink: _interestModel.borrow_rate_on_mid_kink.fields,
+    highKink: _interestModel.high_kink.fields,
+    midKink: _interestModel.mid_kink.fields,
+    minBorrowAmount: _interestModel.min_borrow_amount,
+    isIsolated: !!isolatedAssetKey,
+    supplyLimit: _supplyLimit,
+    borrowLimit: _borrowLimit,
+    parsedOriginMarketCollateral,
+  };
 };
 
 /**
@@ -302,9 +542,19 @@ export const getMarketPool = async (
   query: ScallopQuery,
   poolCoinName: SupportPoolCoins,
   indexer: boolean = false,
-  marketObject?: SuiObjectData | null,
-  coinPrice?: number
-): Promise<MarketPool | undefined> => {
+  coinPrice: number,
+  requiredObjects?: {
+    balanceSheet: SuiObjectData;
+    borrowDynamic: SuiObjectData;
+    interestModel: SuiObjectData;
+    borrowFeeKey: SuiObjectData;
+    supplyLimitKey: SuiObjectData;
+    borrowLimitKey: SuiObjectData;
+    isolatedAssetKey: SuiObjectData;
+  }
+): Promise<
+  { marketPool: MarketPool; collateral?: MarketCollateral } | undefined
+> => {
   coinPrice = coinPrice ?? (await query.utils.getCoinPrices())?.[poolCoinName];
 
   if (indexer) {
@@ -317,202 +567,83 @@ export const getMarketPool = async (
       marketPoolIndexer.coinName
     );
 
-    return marketPoolIndexer;
+    let marketCollateralIndexer: MarketCollateral | undefined = undefined;
+    if (SUPPORT_COLLATERALS.includes(poolCoinName as SupportCollateralCoins)) {
+      marketCollateralIndexer = await query.indexer.getMarketCollateral(
+        poolCoinName as SupportCollateralCoins
+      );
+      marketCollateralIndexer.coinPrice =
+        coinPrice ?? marketCollateralIndexer.coinPrice;
+      marketCollateralIndexer.coinWrappedType = query.utils.getCoinWrappedType(
+        marketCollateralIndexer.coinName
+      );
+    }
+
+    return {
+      marketPool: marketPoolIndexer,
+      collateral: marketCollateralIndexer,
+    };
   }
 
-  const marketId = query.address.get('core.market');
-  marketObject =
-    marketObject ||
-    (
-      await query.cache.queryGetObject(marketId, {
-        showContent: true,
-      })
-    )?.data;
+  requiredObjects ??= (await queryRequiredMarketObjects(query, [poolCoinName]))[
+    poolCoinName
+  ];
 
-  if (!(marketObject && marketObject.content?.dataType === 'moveObject'))
-    throw new Error(`Failed to fetch marketObject`);
-
-  const fields = marketObject.content.fields as any;
-  const coinType = query.utils.parseCoinType(poolCoinName);
-  // Get balance sheet.
-  const balanceSheetParentId =
-    fields.vault.fields.balance_sheets.fields.table.fields.id.id;
-  const balanceSheetDynamicFieldObjectResponse =
-    await query.cache.queryGetDynamicFieldObject({
-      parentId: balanceSheetParentId,
-      name: {
-        type: '0x1::type_name::TypeName',
-        value: {
-          name: coinType.substring(2),
-        },
-      },
-    });
-
-  const balanceSheetDynamicFieldObject =
-    balanceSheetDynamicFieldObjectResponse?.data;
-
-  if (
-    !(
-      balanceSheetDynamicFieldObject &&
-      balanceSheetDynamicFieldObject.content &&
-      'fields' in balanceSheetDynamicFieldObject.content
-    )
-  )
-    throw new Error(
-      `Failed to fetch balanceSheetDynamicFieldObject for ${poolCoinName}: ${balanceSheetDynamicFieldObjectResponse?.error?.code.toString()}`
-    );
-  const balanceSheet: BalanceSheet = (
-    balanceSheetDynamicFieldObject.content.fields as any
-  ).value.fields;
-
-  // Get borrow index.
-  const borrowIndexParentId = fields.borrow_dynamics.fields.table.fields.id.id;
-  const borrowIndexDynamicFieldObjectResponse =
-    await query.cache.queryGetDynamicFieldObject({
-      parentId: borrowIndexParentId,
-      name: {
-        type: '0x1::type_name::TypeName',
-        value: {
-          name: coinType.substring(2),
-        },
-      },
-    });
-
-  const borrowIndexDynamicFieldObject =
-    borrowIndexDynamicFieldObjectResponse?.data;
-  if (
-    !(
-      borrowIndexDynamicFieldObject &&
-      borrowIndexDynamicFieldObject.content &&
-      'fields' in borrowIndexDynamicFieldObject.content
-    )
-  )
-    throw new Error(
-      `Failed to fetch borrowIndexDynamicFieldObject for ${poolCoinName}`
-    );
-  const borrowIndex: BorrowIndex = (
-    borrowIndexDynamicFieldObject.content.fields as any
-  ).value.fields;
-
-  // Get interest models.
-  const interestModelParentId =
-    fields.interest_models.fields.table.fields.id.id;
-  const interestModelDynamicFieldObjectResponse =
-    await query.cache.queryGetDynamicFieldObject({
-      parentId: interestModelParentId,
-      name: {
-        type: '0x1::type_name::TypeName',
-        value: {
-          name: coinType.substring(2),
-        },
-      },
-    });
-
-  const interestModelDynamicFieldObject =
-    interestModelDynamicFieldObjectResponse?.data;
-  if (
-    !(
-      interestModelDynamicFieldObject &&
-      interestModelDynamicFieldObject.content &&
-      'fields' in interestModelDynamicFieldObject.content
-    )
-  )
-    throw new Error(
-      `Failed to fetch interestModelDynamicFieldObject for ${poolCoinName}: ${interestModelDynamicFieldObject}`
-    );
-  const interestModel: InterestModel = (
-    interestModelDynamicFieldObject.content.fields as any
-  ).value.fields;
-
-  // Get borrow fee.
-  const getBorrowFee = async () => {
-    const borrowFeeDynamicFieldObjectResponse =
-      await query.cache.queryGetDynamicFieldObject({
-        parentId: marketId,
-        name: {
-          type: `${BORROW_FEE_PROTOCOL_ID}::market_dynamic_keys::BorrowFeeKey`,
-          value: {
-            type: {
-              name: coinType.substring(2),
-            },
-          },
-        },
-      });
-
-    const borrowFeeDynamicFieldObject =
-      borrowFeeDynamicFieldObjectResponse?.data;
-    if (
-      !(
-        borrowFeeDynamicFieldObject &&
-        borrowFeeDynamicFieldObject.content &&
-        'fields' in borrowFeeDynamicFieldObject.content
-      )
-    )
-      return { value: '0' };
-    return (borrowFeeDynamicFieldObject.content.fields as any).value.fields;
-  };
-
-  const parsedMarketPoolData = parseOriginMarketPoolData({
-    type: interestModel.type.fields,
-    maxBorrowRate: interestModel.max_borrow_rate.fields,
-    interestRate: borrowIndex.interest_rate.fields,
-    interestRateScale: borrowIndex.interest_rate_scale,
-    borrowIndex: borrowIndex.borrow_index,
-    lastUpdated: borrowIndex.last_updated,
-    cash: balanceSheet.cash,
-    debt: balanceSheet.debt,
-    marketCoinSupply: balanceSheet.market_coin_supply,
-    reserve: balanceSheet.revenue,
-    reserveFactor: interestModel.revenue_factor.fields,
-    borrowWeight: interestModel.borrow_weight.fields,
-    borrowFeeRate: await getBorrowFee(),
-    baseBorrowRatePerSec: interestModel.base_borrow_rate_per_sec.fields,
-    borrowRateOnHighKink: interestModel.borrow_rate_on_high_kink.fields,
-    borrowRateOnMidKink: interestModel.borrow_rate_on_mid_kink.fields,
-    highKink: interestModel.high_kink.fields,
-    midKink: interestModel.mid_kink.fields,
-    minBorrowAmount: interestModel.min_borrow_amount,
-  });
-
+  const parsedMarketPoolObjects = parseMarketPoolObjects(requiredObjects);
+  const parsedMarketPoolData = parseOriginMarketPoolData(
+    parsedMarketPoolObjects
+  );
   const calculatedMarketPoolData = calculateMarketPoolData(
     query.utils,
     parsedMarketPoolData
   );
+  const parsedMarketCollateralData =
+    parsedMarketPoolObjects.parsedOriginMarketCollateral
+      ? parseOriginMarketCollateralData(
+          parsedMarketPoolObjects.parsedOriginMarketCollateral
+        )
+      : undefined;
 
-  const coinDecimal = query.utils.getCoinDecimal(poolCoinName);
-  const maxSupplyCoin = BigNumber(
-    (await getSupplyLimit(query.utils, poolCoinName)) ?? '0'
-  )
-    .shiftedBy(-coinDecimal)
-    .toNumber();
-  const maxBorrowCoin = BigNumber(
-    (await getBorrowLimit(query.utils, poolCoinName)) ?? '0'
-  )
-    .shiftedBy(-coinDecimal)
-    .toNumber();
-
-  return {
-    coinName: poolCoinName,
+  const basePoolData = <T extends SupportPoolCoins = SupportPoolCoins>() => ({
+    coinName: poolCoinName as T,
     symbol: query.utils.parseSymbol(poolCoinName),
-    coinType: query.utils.parseCoinType(poolCoinName),
     marketCoinType: query.utils.parseMarketCoinType(poolCoinName),
-    sCoinType: query.utils.parseSCoinType(
-      query.utils.parseMarketCoinName(poolCoinName)
-    ),
-    coinWrappedType: query.utils.getCoinWrappedType(poolCoinName),
-    coinDecimal,
-    coinPrice: coinPrice ?? 0,
-    highKink: parsedMarketPoolData.highKink,
-    midKink: parsedMarketPoolData.midKink,
-    reserveFactor: parsedMarketPoolData.reserveFactor,
-    borrowWeight: parsedMarketPoolData.borrowWeight,
-    borrowFee: parsedMarketPoolData.borrowFee,
-    marketCoinSupplyAmount: parsedMarketPoolData.marketCoinSupplyAmount,
-    minBorrowAmount: parsedMarketPoolData.minBorrowAmount,
-    maxSupplyCoin,
-    maxBorrowCoin,
-    isIsolated: await isIsolatedAsset(query.utils, poolCoinName),
-    ...calculatedMarketPoolData,
+    coinType: query.utils.parseCoinType(poolCoinName),
+  });
+  return {
+    marketPool: {
+      ...basePoolData(),
+      sCoinType: query.utils.parseSCoinType(
+        query.utils.parseMarketCoinName(poolCoinName)
+      ),
+      coinWrappedType: query.utils.getCoinWrappedType(poolCoinName),
+      coinPrice: coinPrice ?? 0,
+      highKink: parsedMarketPoolData.highKink,
+      midKink: parsedMarketPoolData.midKink,
+      reserveFactor: parsedMarketPoolData.reserveFactor,
+      borrowWeight: parsedMarketPoolData.borrowWeight,
+      borrowFee: parsedMarketPoolData.borrowFee,
+      marketCoinSupplyAmount: parsedMarketPoolData.marketCoinSupplyAmount,
+      minBorrowAmount: parsedMarketPoolData.minBorrowAmount,
+      ...calculatedMarketPoolData,
+    },
+    collateral: parsedMarketCollateralData
+      ? {
+          ...basePoolData<SupportCollateralCoins>(),
+          coinWrappedType: query.utils.getCoinWrappedType(poolCoinName),
+          coinPrice: coinPrice,
+          collateralFactor: parsedMarketCollateralData.collateralFactor,
+          liquidationFactor: parsedMarketCollateralData.liquidationFactor,
+          liquidationDiscount: parsedMarketCollateralData.liquidationDiscount,
+          liquidationPenalty: parsedMarketCollateralData.liquidationPenalty,
+          liquidationReserveFactor:
+            parsedMarketCollateralData.liquidationReserveFactor,
+          ...calculateMarketCollateralData(
+            query.utils,
+            parsedMarketCollateralData
+          ),
+        }
+      : undefined,
   };
 };
 
@@ -691,10 +822,11 @@ export const getMarketCollateral = async (
     collateralFactor: riskModel.collateral_factor.fields,
     liquidationFactor: riskModel.liquidation_factor.fields,
     liquidationDiscount: riskModel.liquidation_discount.fields,
-    liquidationPanelty: riskModel.liquidation_penalty.fields,
+    liquidationPenalty: riskModel.liquidation_penalty.fields,
     liquidationReserveFactor: riskModel.liquidation_revenue_factor.fields,
     maxCollateralAmount: riskModel.max_collateral_amount,
     totalCollateralAmount: collateralStat.amount,
+    isIsolated: await isIsolatedAsset(query.utils, collateralCoinName),
   });
 
   const calculatedMarketCollateralData = calculateMarketCollateralData(
@@ -708,15 +840,13 @@ export const getMarketCollateral = async (
     coinType: query.utils.parseCoinType(collateralCoinName),
     marketCoinType: query.utils.parseMarketCoinType(collateralCoinName),
     coinWrappedType: query.utils.getCoinWrappedType(collateralCoinName),
-    coinDecimal: query.utils.getCoinDecimal(collateralCoinName),
     coinPrice: coinPrice ?? 0,
     collateralFactor: parsedMarketCollateralData.collateralFactor,
     liquidationFactor: parsedMarketCollateralData.liquidationFactor,
     liquidationDiscount: parsedMarketCollateralData.liquidationDiscount,
-    liquidationPanelty: parsedMarketCollateralData.liquidationPanelty,
+    liquidationPenalty: parsedMarketCollateralData.liquidationPenalty,
     liquidationReserveFactor:
       parsedMarketCollateralData.liquidationReserveFactor,
-    isIsolated: await isIsolatedAsset(query.utils, collateralCoinName),
     ...calculatedMarketCollateralData,
   };
 };

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -10,3 +10,5 @@ export * from './spoolQuery';
 export * from './supplyLimitQuery';
 export * from './vescaQuery';
 export * from './borrowLimitQuery';
+export * from './poolAddressesQuery';
+export * from './objectsQuery';

--- a/src/queries/objectsQuery.ts
+++ b/src/queries/objectsQuery.ts
@@ -1,0 +1,20 @@
+import { SuiObjectDataOptions } from '@mysten/sui/dist/cjs/client';
+import { ScallopCache } from 'src/models/scallopCache';
+import { partitionArray } from 'src/utils';
+
+export const queryMultipleObjects = async (
+  cache: ScallopCache,
+  objectIds: string[],
+  options?: SuiObjectDataOptions,
+  partitionSize = 50
+) => {
+  const objectIdsPartition = partitionArray(objectIds, partitionSize);
+
+  const objects = [];
+  for (const objectIds of objectIdsPartition) {
+    const result = await cache.queryGetObjects(objectIds, options);
+    objects.push(...result);
+  }
+
+  return objects;
+};

--- a/src/queries/poolAddressesQuery.ts
+++ b/src/queries/poolAddressesQuery.ts
@@ -1,0 +1,134 @@
+import { SUPPORT_POOLS } from 'src/constants';
+import { ScallopQuery } from 'src/models';
+import { OptionalKeys, SupportPoolCoins, SupportSCoin } from 'src/types';
+
+export const getAllAddresses = async (query: ScallopQuery) => {
+  const results: OptionalKeys<
+    Record<
+      SupportPoolCoins,
+      {
+        lendingPoolAddress?: string;
+        collateralPoolAddress?: string; // not all pool has collateral
+        borrowDynamic?: string;
+        spoolReward?: string;
+        spool?: string;
+        interestModel?: string;
+        riskModel?: string;
+        borrowFeeKey?: string;
+        supplyLimitKey?: string;
+        borrowLimitKey?: string;
+        isolatedAssetKey?: string;
+      }
+    >
+  > = {};
+
+  const marketId = query.address.get('core.market');
+  const marketObject = (
+    await query.cache.queryGetObject(marketId, {
+      showContent: true,
+    })
+  )?.data;
+
+  if (!(marketObject && marketObject.content?.dataType === 'moveObject'))
+    throw new Error(`Failed to fetch marketObject`);
+
+  const fields = marketObject.content.fields as any;
+
+  const coinTypesPairs = SUPPORT_POOLS.reduce(
+    (acc, pool) => {
+      acc.push([pool, query.utils.parseCoinType(pool).substring(2)]);
+      return acc;
+    },
+    [] as [SupportPoolCoins, string][]
+  );
+  const balanceSheetParentId =
+    fields.vault.fields.balance_sheets.fields.table.fields.id.id;
+
+  const collateralStatsParentId =
+    fields.collateral_stats.fields.table.fields.id.id;
+
+  const borrowDynamicsParentid =
+    fields.borrow_dynamics.fields.table.fields.id.id;
+
+  const interestModelParentId =
+    fields.interest_models.fields.table.fields.id.id;
+
+  const riskModelParentId = fields.risk_models.fields.table.fields.id.id;
+
+  const ADDRESS_TYPE = `0x1::type_name::TypeName`;
+  const BORROW_FEE_TYPE = `0xc38f849e81cfe46d4e4320f508ea7dda42934a329d5a6571bb4c3cb6ea63f5da::market_dynamic_keys::BorrowFeeKey`;
+  const SUPPLY_LIMIT_TYPE = `0x6e641f0dca8aedab3101d047e96439178f16301bf0b57fe8745086ff1195eb3e::market_dynamic_keys::SupplyLimitKey`;
+  const BORROW_LIMIT_TYPE = `0xe7dbb371a9595631f7964b7ece42255ad0e738cc85fe6da26c7221b220f01af6::market_dynamic_keys::BorrowLimitKey`; // prod
+  const ISOLATED_ASSET_KEY = `0xe7dbb371a9595631f7964b7ece42255ad0e738cc85fe6da26c7221b220f01af6::market_dynamic_keys::IsolatedAssetKey`;
+  const fetchDynamicObject = async (
+    parentId: string,
+    type: string,
+    value: any
+  ) => {
+    try {
+      return (
+        await query.cache.queryGetDynamicFieldObject({
+          parentId,
+          name: {
+            type,
+            value,
+          },
+        })
+      )?.data?.objectId;
+    } catch (_e) {
+      return undefined;
+    }
+  };
+
+  await Promise.all(
+    coinTypesPairs.map(async ([coinName, coinType]) => {
+      const addresses = await Promise.all([
+        fetchDynamicObject(balanceSheetParentId, ADDRESS_TYPE, {
+          name: coinType,
+        }),
+        fetchDynamicObject(collateralStatsParentId, ADDRESS_TYPE, {
+          name: coinType,
+        }),
+        fetchDynamicObject(borrowDynamicsParentid, ADDRESS_TYPE, {
+          name: coinType,
+        }),
+        fetchDynamicObject(interestModelParentId, ADDRESS_TYPE, {
+          name: coinType,
+        }),
+        fetchDynamicObject(riskModelParentId, ADDRESS_TYPE, {
+          name: coinType,
+        }),
+        fetchDynamicObject(marketId, BORROW_FEE_TYPE, coinType),
+        fetchDynamicObject(marketId, SUPPLY_LIMIT_TYPE, coinType),
+        fetchDynamicObject(marketId, BORROW_LIMIT_TYPE, coinType),
+        fetchDynamicObject(marketId, ISOLATED_ASSET_KEY, coinType),
+      ]);
+
+      const spool = query.address.get(
+        // @ts-ignore
+        `spool.pools.s${coinName as SupportSCoin}.id`
+      );
+      const rewardPool = query.address.get(
+        // @ts-ignore
+        `spool.pools.s${coinName}.rewardPoolId`
+      );
+      results[coinName as SupportPoolCoins] = {
+        lendingPoolAddress: addresses[0],
+        collateralPoolAddress: addresses[1],
+        borrowDynamic: addresses[2],
+        interestModel: addresses[3],
+        riskModel: addresses[4],
+        borrowFeeKey: addresses[5],
+        supplyLimitKey: addresses[6],
+        borrowLimitKey: addresses[7],
+        isolatedAssetKey: addresses[8],
+        spool,
+        spoolReward: rewardPool,
+      };
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    })
+  );
+
+  return results;
+};

--- a/src/queries/poolAddressesQuery.ts
+++ b/src/queries/poolAddressesQuery.ts
@@ -19,6 +19,8 @@ export const getAllAddresses = async (query: ScallopQuery) => {
         supplyLimitKey?: string;
         borrowLimitKey?: string;
         isolatedAssetKey?: string;
+        coinDecimalId?: string;
+        borrowIncentivePoolId?: string;
       }
     >
   > = {};
@@ -117,6 +119,9 @@ export const getAllAddresses = async (query: ScallopQuery) => {
         // @ts-ignore
         `scoin.coins.s${coinName}.treasury`
       );
+      const coinDecimalId = query.address.get(
+        `core.coins.${coinName}.metaData`
+      );
       results[coinName as SupportPoolCoins] = {
         lendingPoolAddress: addresses[0],
         collateralPoolAddress: addresses[1],
@@ -130,6 +135,7 @@ export const getAllAddresses = async (query: ScallopQuery) => {
         spool,
         spoolReward: rewardPool,
         sCoinTreasury,
+        coinDecimalId,
       };
 
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/src/queries/poolAddressesQuery.ts
+++ b/src/queries/poolAddressesQuery.ts
@@ -1,6 +1,6 @@
 import { SUPPORT_POOLS } from 'src/constants';
 import { ScallopQuery } from 'src/models';
-import { OptionalKeys, SupportPoolCoins, SupportSCoin } from 'src/types';
+import { OptionalKeys, SupportPoolCoins } from 'src/types';
 
 export const getAllAddresses = async (query: ScallopQuery) => {
   const results: OptionalKeys<
@@ -12,6 +12,7 @@ export const getAllAddresses = async (query: ScallopQuery) => {
         borrowDynamic?: string;
         spoolReward?: string;
         spool?: string;
+        sCoinTreasury?: string;
         interestModel?: string;
         riskModel?: string;
         borrowFeeKey?: string;
@@ -106,11 +107,15 @@ export const getAllAddresses = async (query: ScallopQuery) => {
 
       const spool = query.address.get(
         // @ts-ignore
-        `spool.pools.s${coinName as SupportSCoin}.id`
+        `spool.pools.s${coinName}.id`
       );
       const rewardPool = query.address.get(
         // @ts-ignore
         `spool.pools.s${coinName}.rewardPoolId`
+      );
+      const sCoinTreasury = query.address.get(
+        // @ts-ignore
+        `scoin.coins.s${coinName}.treasury`
       );
       results[coinName as SupportPoolCoins] = {
         lendingPoolAddress: addresses[0],
@@ -124,6 +129,7 @@ export const getAllAddresses = async (query: ScallopQuery) => {
         isolatedAssetKey: addresses[8],
         spool,
         spoolReward: rewardPool,
+        sCoinTreasury,
       };
 
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -51,10 +51,13 @@ export const getLendings = async (
   ) as SupportStakeMarketCoins[];
 
   const coinPrices = await query.utils.getCoinPrices();
-  const marketPools = await query.getMarketPools(poolCoinNames, {
-    indexer,
-    coinPrices,
-  });
+  const marketPools = (
+    await query.getMarketPools(poolCoinNames, {
+      indexer,
+      coinPrices,
+    })
+  ).pools;
+
   const spools = await query.getSpools(stakeMarketCoinNames, {
     indexer,
     marketPools,
@@ -309,7 +312,8 @@ export const getObligationAccounts = async (
   indexer: boolean = false
 ) => {
   const coinPrices = await query.utils.getCoinPrices();
-  const market = await query.queryMarket({ indexer, coinPrices });
+  // const market = await query.queryMarket({ indexer, coinPrices });
+  const market = await query.getMarketPools(undefined, { coinPrices, indexer });
   const [coinAmounts, obligations] = await Promise.all([
     query.getCoinAmounts(undefined, ownerAddress),
     query.getObligations(ownerAddress),
@@ -357,7 +361,8 @@ export const getObligationAccount = async (
     ...SUPPORT_COLLATERALS,
   ] as SupportCollateralCoins[];
 
-  market = market ?? (await query.queryMarket({ indexer }));
+  // market = market ?? (await query.queryMarket({ indexer }));
+  market = market ?? (await query.getMarketPools(undefined, { indexer }));
   coinPrices =
     coinPrices ?? (await query.getAllCoinPrices({ marketPools: market.pools }));
   coinAmounts =
@@ -784,7 +789,8 @@ export const getTotalValueLocked = async (
   query: ScallopQuery,
   indexer: boolean = false
 ) => {
-  const market = await query.queryMarket({ indexer });
+  // const market = await query.queryMarket({ indexer });
+  const market = await query.getMarketPools(undefined, { indexer });
 
   let supplyValue = BigNumber(0);
   let borrowValue = BigNumber(0);
@@ -811,6 +817,7 @@ export const getTotalValueLocked = async (
     );
   }
 
+  // console.dir(market.collaterals, { depth: null });
   for (const collateral of Object.values(market.collaterals)) {
     supplyValue = supplyValue.plus(
       BigNumber(collateral.depositCoin).multipliedBy(collateral.coinPrice)

--- a/src/queries/portfolioQuery.ts
+++ b/src/queries/portfolioQuery.ts
@@ -366,7 +366,7 @@ export const getObligationAccount = async (
   coinPrices =
     coinPrices ?? (await query.getAllCoinPrices({ marketPools: market.pools }));
   coinAmounts =
-    coinAmounts || (await query.getCoinAmounts(coinNames, ownerAddress));
+    coinAmounts ?? (await query.getCoinAmounts(coinNames, ownerAddress));
 
   const [obligationQuery, borrowIncentivePools, borrowIncentiveAccounts] =
     await Promise.all([

--- a/src/queries/priceQuery.ts
+++ b/src/queries/priceQuery.ts
@@ -142,7 +142,9 @@ export const getAllCoinPrices = async (
 ) => {
   coinPrices = coinPrices ?? (await query.utils.getCoinPrices());
   marketPools =
-    marketPools ?? (await query.getMarketPools(undefined, { coinPrices }));
+    marketPools ??
+    (await query.getMarketPools(undefined, { coinPrices })).pools;
+
   if (!marketPools) {
     throw new Error(`Failed to fetch market pool for getAllCoinPrices`);
   }

--- a/src/queries/spoolQuery.ts
+++ b/src/queries/spoolQuery.ts
@@ -1,16 +1,16 @@
 import { normalizeStructTag } from '@mysten/sui/utils';
-import { SUPPORT_SPOOLS } from '../constants';
+import { POOL_ADDRESSES, SUPPORT_SPOOLS } from '../constants';
 import {
   parseOriginSpoolData,
   calculateSpoolData,
   parseOriginSpoolRewardPoolData,
   calculateSpoolRewardPoolData,
   isMarketCoin,
+  parseObjectAs,
 } from '../utils';
-import type { SuiObjectResponse } from '@mysten/sui/client';
+import type { SuiObjectData, SuiObjectResponse } from '@mysten/sui/client';
 import type { ScallopQuery, ScallopUtils } from '../models';
 import type {
-  MarketPool,
   Spools,
   Spool,
   StakePool,
@@ -20,7 +20,107 @@ import type {
   SupportStakeCoins,
   CoinPrices,
   MarketPools,
+  OriginSpoolRewardPoolData,
+  SpoolData,
+  OriginSpoolData,
 } from '../types';
+import { queryMultipleObjects } from './objectsQuery';
+
+const queryRequiredSpoolObjects = async (
+  query: ScallopQuery,
+  stakePoolCoinNames: SupportStakeCoins[]
+) => {
+  // Prepare all tasks for querying each object type
+  const tasks = stakePoolCoinNames.map((t, idx) => ({
+    poolCoinName: stakePoolCoinNames[idx],
+    spool: POOL_ADDRESSES[t]?.spool,
+    spoolReward: POOL_ADDRESSES[t]?.spoolReward,
+    sCoinTreasury: POOL_ADDRESSES[t]?.sCoinTreasury,
+  }));
+
+  // Query all objects for each key in parallel
+  const [spoolObjects, spoolRewardObjects, sCoinTreasuryObjects] =
+    await Promise.all([
+      queryMultipleObjects(
+        query.cache,
+        tasks.map((task) => task.spool).filter((t): t is string => !!t)
+      ),
+      queryMultipleObjects(
+        query.cache,
+        tasks.map((task) => task.spoolReward).filter((t): t is string => !!t)
+      ),
+      queryMultipleObjects(
+        query.cache,
+        tasks.map((task) => task.sCoinTreasury).filter((t): t is string => !!t)
+      ),
+    ]);
+
+  // Map the results back to poolCoinNames
+  const mapObjects = (
+    tasks: { poolCoinName: string; [key: string]: string | undefined }[],
+    fetchedObjects: SuiObjectData[]
+  ) => {
+    const resultMap: Record<string, SuiObjectData> = {};
+    let fetchedIndex = 0;
+
+    for (const task of tasks) {
+      const key = task[Object.keys(task)[1]]; // current object key being queried
+      if (key) {
+        resultMap[task.poolCoinName] = fetchedObjects[fetchedIndex];
+        fetchedIndex++;
+      }
+    }
+    return resultMap;
+  };
+
+  const spoolMap = mapObjects(tasks, spoolObjects);
+  const spoolRewardMap = mapObjects(tasks, spoolRewardObjects);
+  const sCoinTreasuryMap = mapObjects(tasks, sCoinTreasuryObjects);
+
+  // Construct the final requiredObjects result
+  return stakePoolCoinNames.reduce(
+    (acc, name) => {
+      acc[name] = {
+        spool: spoolMap[name],
+        spoolReward: spoolRewardMap[name],
+        sCoinTreasury: sCoinTreasuryMap[name],
+      };
+      return acc;
+    },
+    {} as Record<
+      SupportStakeCoins,
+      {
+        spool: SuiObjectData;
+        spoolReward: SuiObjectData;
+        sCoinTreasury: SuiObjectData;
+      }
+    >
+  );
+};
+
+const parseSpoolObjects = ({
+  spool,
+  spoolReward,
+}: {
+  spool: SuiObjectData;
+  spoolReward: SuiObjectData;
+}): OriginSpoolData & OriginSpoolRewardPoolData => {
+  const _spool = parseObjectAs<SpoolData>(spool);
+  const _spoolReward = parseObjectAs<OriginSpoolRewardPoolData>(spoolReward);
+  return {
+    stakeType: _spool.stake_type,
+    maxDistributedPoint: _spool.max_distributed_point,
+    distributedPoint: _spool.distributed_point,
+    distributedPointPerPeriod: _spool.distributed_point_per_period,
+    pointDistributionTime: _spool.point_distribution_time,
+    maxStake: _spool.max_stakes,
+    stakes: _spool.stakes,
+    index: _spool.index,
+    createdAt: _spool.created_at,
+    lastUpdate: _spool.last_update,
+    ..._spoolReward,
+  };
+};
 
 /**
  * Get spools data.
@@ -40,11 +140,12 @@ export const getSpools = async (
   const stakeCoinNames = stakeMarketCoinNames.map((stakeMarketCoinName) =>
     query.utils.parseCoinName<SupportStakeCoins>(stakeMarketCoinName)
   );
-  coinPrices = coinPrices ?? (await query.utils.getCoinPrices()) ?? {};
-
   marketPools =
     marketPools ??
     (await query.getMarketPools(stakeCoinNames, { indexer })).pools;
+
+  coinPrices =
+    coinPrices ?? (await query.getAllCoinPrices({ marketPools })) ?? {};
 
   if (!marketPools)
     throw new Error(`Fail to fetch marketPools for ${stakeCoinNames}`);
@@ -61,12 +162,9 @@ export const getSpools = async (
       const rewardCoinName = query.utils.getSpoolRewardCoinName(
         spool.marketCoinName
       );
-      const marketPool = marketPools[coinName];
       spool.coinPrice = coinPrices[coinName] ?? spool.coinPrice;
-      spool.marketCoinPrice = coinPrices[coinName]
-        ? (coinPrices[coinName] ?? 0) *
-          (marketPool ? marketPool.conversionRate : 0)
-        : spool.marketCoinPrice;
+      spool.marketCoinPrice =
+        coinPrices[spool.marketCoinName] ?? spool.marketCoinPrice;
       spool.rewardCoinPrice =
         coinPrices[rewardCoinName] ?? spool.rewardCoinPrice;
       spools[spool.marketCoinName] = spool;
@@ -76,21 +174,31 @@ export const getSpools = async (
     return spools;
   }
 
-  for (const stakeMarketCoinName of stakeMarketCoinNames) {
-    const stakeCoinName =
-      query.utils.parseCoinName<SupportStakeCoins>(stakeMarketCoinName);
-    const spool = await getSpool(
-      query,
-      stakeMarketCoinName,
-      indexer,
-      marketPools[stakeCoinName],
-      coinPrices
-    );
+  const requiredObjects = await queryRequiredSpoolObjects(
+    query,
+    stakeCoinNames
+  );
 
-    if (spool) {
-      spools[stakeMarketCoinName] = spool;
-    }
-  }
+  await Promise.allSettled(
+    stakeMarketCoinNames.map(async (stakeMarketCoinName, idx) => {
+      try {
+        const stakeCoinName = stakeCoinNames[idx];
+        const spool = await getSpool(
+          query,
+          stakeMarketCoinName,
+          indexer,
+          coinPrices,
+          requiredObjects[stakeCoinName]
+        );
+
+        if (spool) {
+          spools[stakeMarketCoinName] = spool;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    })
+  );
 
   return spools;
 };
@@ -109,126 +217,83 @@ export const getSpool = async (
   query: ScallopQuery,
   marketCoinName: SupportStakeMarketCoins,
   indexer: boolean = false,
-  marketPool?: MarketPool,
-  coinPrices?: CoinPrices
+  coinPrices?: CoinPrices,
+  requiredObjects?: {
+    spool: SuiObjectData;
+    spoolReward: SuiObjectData;
+  }
 ) => {
   const coinName = query.utils.parseCoinName<SupportStakeCoins>(marketCoinName);
-  marketPool = marketPool || (await query.getMarketPool(coinName, { indexer }));
-  if (!marketPool) {
-    throw new Error(`Failed to fetch marketPool for ${marketCoinName}`);
-  }
-
-  const poolId = query.address.get(`spool.pools.${marketCoinName}.id`);
-  const rewardPoolId = query.address.get(
-    `spool.pools.${marketCoinName}.rewardPoolId`
-  );
-  let spool: Spool | undefined = undefined;
-  coinPrices = coinPrices || (await query.utils.getCoinPrices());
+  coinPrices = coinPrices || (await query.getAllCoinPrices());
 
   if (indexer) {
     const spoolIndexer = await query.indexer.getSpool(marketCoinName);
     const coinName =
       query.utils.parseCoinName<SupportStakeCoins>(marketCoinName);
     const rewardCoinName = query.utils.getSpoolRewardCoinName(marketCoinName);
-    spoolIndexer.coinPrice = coinPrices?.[coinName] || spoolIndexer.coinPrice;
+    spoolIndexer.coinPrice = coinPrices?.[coinName] ?? spoolIndexer.coinPrice;
     spoolIndexer.marketCoinPrice =
-      (coinPrices?.[coinName] ?? 0) *
-        (marketPool ? marketPool.conversionRate : 0) ||
-      spoolIndexer.marketCoinPrice;
+      coinPrices?.[marketCoinName] ?? spoolIndexer.marketCoinPrice;
     spoolIndexer.rewardCoinPrice =
-      coinPrices?.[rewardCoinName] || spoolIndexer.rewardCoinPrice;
+      coinPrices?.[rewardCoinName] ?? spoolIndexer.rewardCoinPrice;
 
     return spoolIndexer;
   }
 
-  const spoolObjectResponse = await query.cache.queryGetObjects(
-    [poolId, rewardPoolId],
-    {
-      showContent: true,
-    }
-  );
-
-  if (!(spoolObjectResponse[0] && spoolObjectResponse[1])) {
-    throw new Error('Fail to fetch spoolObjectResponse!');
-  }
+  requiredObjects ??= (await queryRequiredSpoolObjects(query, [coinName]))[
+    coinName
+  ];
 
   const rewardCoinName = query.utils.getSpoolRewardCoinName(marketCoinName);
   coinPrices = coinPrices || (await query.utils.getCoinPrices());
 
-  const spoolObject = spoolObjectResponse[0];
-  const rewardPoolObject = spoolObjectResponse[1];
-  if (spoolObject.content && 'fields' in spoolObject.content) {
-    const spoolFields = spoolObject.content.fields as any;
-    const parsedSpoolData = parseOriginSpoolData({
-      stakeType: spoolFields.stake_type,
-      maxDistributedPoint: spoolFields.max_distributed_point,
-      distributedPoint: spoolFields.distributed_point,
-      distributedPointPerPeriod: spoolFields.distributed_point_per_period,
-      pointDistributionTime: spoolFields.point_distribution_time,
-      maxStake: spoolFields.max_stakes,
-      stakes: spoolFields.stakes,
-      index: spoolFields.index,
-      createdAt: spoolFields.created_at,
-      lastUpdate: spoolFields.last_update,
-    });
+  const parsedSpoolObjects = parseSpoolObjects(requiredObjects);
+  const parsedSpoolData = parseOriginSpoolData(parsedSpoolObjects);
 
-    const marketCoinPrice =
-      (coinPrices?.[coinName] ?? 0) * marketPool.conversionRate;
-    const marketCoinDecimal = query.utils.getCoinDecimal(marketCoinName);
-    const calculatedSpoolData = calculateSpoolData(
-      parsedSpoolData,
-      marketCoinPrice,
-      marketCoinDecimal
-    );
+  const marketCoinPrice = coinPrices?.[marketCoinName] ?? 0;
+  const marketCoinDecimal = query.utils.getCoinDecimal(marketCoinName);
+  const calculatedSpoolData = calculateSpoolData(
+    parsedSpoolData,
+    marketCoinPrice,
+    marketCoinDecimal
+  );
 
-    if (rewardPoolObject.content && 'fields' in rewardPoolObject.content) {
-      const rewardPoolFields = rewardPoolObject.content.fields as any;
-      const parsedSpoolRewardPoolData = parseOriginSpoolRewardPoolData({
-        claimed_rewards: rewardPoolFields.claimed_rewards,
-        exchange_rate_numerator: rewardPoolFields.exchange_rate_numerator,
-        exchange_rate_denominator: rewardPoolFields.exchange_rate_denominator,
-        rewards: rewardPoolFields.rewards,
-        spool_id: rewardPoolFields.spool_id,
-      });
+  const parsedSpoolRewardPoolData =
+    parseOriginSpoolRewardPoolData(parsedSpoolObjects);
 
-      const rewardCoinPrice = coinPrices?.[rewardCoinName] ?? 0;
-      const rewardCoinDecimal = query.utils.getCoinDecimal(rewardCoinName);
+  const rewardCoinPrice = coinPrices?.[rewardCoinName] ?? 0;
+  const rewardCoinDecimal = query.utils.getCoinDecimal(rewardCoinName);
 
-      const calculatedRewardPoolData = calculateSpoolRewardPoolData(
-        parsedSpoolData,
-        parsedSpoolRewardPoolData,
-        calculatedSpoolData,
-        rewardCoinPrice,
-        rewardCoinDecimal
-      );
+  const calculatedRewardPoolData = calculateSpoolRewardPoolData(
+    parsedSpoolData,
+    parsedSpoolRewardPoolData,
+    calculatedSpoolData,
+    rewardCoinPrice,
+    rewardCoinDecimal
+  );
 
-      spool = {
-        marketCoinName: marketCoinName,
-        symbol: query.utils.parseSymbol(marketCoinName),
-        coinType: query.utils.parseCoinType(coinName),
-        marketCoinType: query.utils.parseMarketCoinType(coinName),
-        rewardCoinType: isMarketCoin(rewardCoinName)
-          ? query.utils.parseMarketCoinType(rewardCoinName)
-          : query.utils.parseCoinType(rewardCoinName),
-        sCoinType: marketPool.sCoinType,
-        coinDecimal: query.utils.getCoinDecimal(coinName),
-        rewardCoinDecimal: query.utils.getCoinDecimal(rewardCoinName),
-        coinPrice: coinPrices?.[coinName] ?? 0,
-        marketCoinPrice: marketCoinPrice,
-        rewardCoinPrice: rewardCoinPrice,
-        maxPoint: parsedSpoolData.maxPoint,
-        distributedPoint: parsedSpoolData.distributedPoint,
-        maxStake: parsedSpoolData.maxStake,
-        ...calculatedSpoolData,
-        exchangeRateNumerator: parsedSpoolRewardPoolData.exchangeRateNumerator,
-        exchangeRateDenominator:
-          parsedSpoolRewardPoolData.exchangeRateDenominator,
-        ...calculatedRewardPoolData,
-      };
-    }
-  }
-
-  return spool;
+  return {
+    marketCoinName: marketCoinName,
+    symbol: query.utils.parseSymbol(marketCoinName),
+    coinType: query.utils.parseCoinType(coinName),
+    marketCoinType: query.utils.parseMarketCoinType(coinName),
+    rewardCoinType: isMarketCoin(rewardCoinName)
+      ? query.utils.parseMarketCoinType(rewardCoinName)
+      : query.utils.parseCoinType(rewardCoinName),
+    sCoinType: query.utils.parseSCoinType(marketCoinName),
+    coinDecimal: query.utils.getCoinDecimal(coinName),
+    rewardCoinDecimal: query.utils.getCoinDecimal(rewardCoinName),
+    coinPrice: coinPrices?.[coinName] ?? 0,
+    marketCoinPrice: marketCoinPrice,
+    rewardCoinPrice: rewardCoinPrice,
+    maxPoint: parsedSpoolData.maxPoint,
+    distributedPoint: parsedSpoolData.distributedPoint,
+    maxStake: parsedSpoolData.maxStake,
+    ...calculatedSpoolData,
+    exchangeRateNumerator: parsedSpoolRewardPoolData.exchangeRateNumerator,
+    exchangeRateDenominator: parsedSpoolRewardPoolData.exchangeRateDenominator,
+    ...calculatedRewardPoolData,
+  };
 };
 
 /**

--- a/src/queries/spoolQuery.ts
+++ b/src/queries/spoolQuery.ts
@@ -43,7 +43,9 @@ export const getSpools = async (
   coinPrices = coinPrices ?? (await query.utils.getCoinPrices()) ?? {};
 
   marketPools =
-    marketPools ?? (await query.getMarketPools(stakeCoinNames, { indexer }));
+    marketPools ??
+    (await query.getMarketPools(stakeCoinNames, { indexer })).pools;
+
   if (!marketPools)
     throw new Error(`Fail to fetch marketPools for ${stakeCoinNames}`);
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,17 @@
+import { ScallopQuery } from './models';
+
+const main = async () => {
+  try {
+    const query = new ScallopQuery({});
+    await query.init();
+
+    const res = await query.getSpool('ssui');
+    console.dir(res, { depth: null });
+  } catch (e) {
+    console.error(e);
+  } finally {
+    process.exit(0);
+  }
+};
+
+main();

--- a/src/types/builder/borrowIncentive.ts
+++ b/src/types/builder/borrowIncentive.ts
@@ -19,22 +19,25 @@ export type BorrowIncentiveNormalMethods = {
   stakeObligation: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg
-  ) => void;
+  ) => Promise<void>;
   stakeObligationWithVesca: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     veScaKey: SuiObjectArg
-  ) => void;
+  ) => Promise<void>;
   unstakeObligation: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg
-  ) => void;
+  ) => Promise<void>;
   claimBorrowIncentive: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     rewardType: SupportBorrowIncentiveRewardCoins
-  ) => TransactionResult;
-  deactivateBoost: (obligation: SuiObjectArg, veScaKey: SuiObjectArg) => void;
+  ) => Promise<TransactionResult>;
+  deactivateBoost: (
+    obligation: SuiObjectArg,
+    veScaKey: SuiObjectArg
+  ) => Promise<void>;
 };
 
 export type BorrowIncentiveQuickMethods = {

--- a/src/types/builder/core.ts
+++ b/src/types/builder/core.ts
@@ -1,6 +1,7 @@
 import type {
   SuiTxBlock as SuiKitTxBlock,
   SuiObjectArg,
+  SuiTxArg,
 } from '@scallop-io/sui-kit';
 import type { Argument, TransactionResult } from '@mysten/sui/transactions';
 import type { ScallopBuilder } from '../../models';
@@ -65,7 +66,7 @@ export type CoreNormalMethods = {
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     borrowReferral: SuiObjectArg,
-    amount: number,
+    amount: number | SuiTxArg,
     poolCoinName: SupportPoolCoins
   ) => TransactionResult;
   borrowEntry: (
@@ -80,7 +81,7 @@ export type CoreNormalMethods = {
     poolCoinName: SupportPoolCoins
   ) => void;
   borrowFlashLoan: (
-    amount: number,
+    amount: number | SuiTxArg,
     poolCoinName: SupportPoolCoins
   ) => TransactionResult;
   repayFlashLoan: (

--- a/src/types/builder/core.ts
+++ b/src/types/builder/core.ts
@@ -26,69 +26,74 @@ type ObligationKey = NestedResult;
 type ObligationHotPotato = NestedResult;
 
 export type CoreNormalMethods = {
-  openObligation: () => [Obligation, ObligationKey, ObligationHotPotato];
+  openObligation: () => Promise<
+    [Obligation, ObligationKey, ObligationHotPotato]
+  >;
   returnObligation: (
     obligation: SuiObjectArg,
     obligationHotPotato: SuiObjectArg
-  ) => void;
-  openObligationEntry: () => void;
+  ) => Promise<void>;
+  openObligationEntry: () => Promise<void>;
   addCollateral: (
     obligation: SuiObjectArg,
     coin: SuiObjectArg,
     collateralCoinName: SupportCollateralCoins
-  ) => void;
+  ) => Promise<void>;
   takeCollateral: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     amount: number,
     collateralCoinName: SupportCollateralCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   deposit: (
     coin: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => TransactionResult;
-  depositEntry: (coin: SuiObjectArg, poolCoinName: SupportPoolCoins) => void;
+  ) => Promise<TransactionResult>;
+  depositEntry: (
+    coin: SuiObjectArg,
+    poolCoinName: SupportPoolCoins
+  ) => Promise<TransactionResult>;
   withdraw: (
     marketCoin: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   withdrawEntry: (
     marketCoin: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => void;
+  ) => Promise<TransactionResult>;
   borrow: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     amount: number,
     poolCoinName: SupportPoolCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   borrowWithReferral: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     borrowReferral: SuiObjectArg,
     amount: number | SuiTxArg,
     poolCoinName: SupportPoolCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   borrowEntry: (
     obligation: SuiObjectArg,
     obligationKey: SuiObjectArg,
     amount: number,
     poolCoinName: SupportPoolCoins
-  ) => void;
+  ) => Promise<TransactionResult>;
   repay: (
     obligation: SuiObjectArg,
     coin: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => void;
+  ) => Promise<void>;
   borrowFlashLoan: (
     amount: number | SuiTxArg,
     poolCoinName: SupportPoolCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   repayFlashLoan: (
     coin: SuiObjectArg,
     loan: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => void;
+  ) => Promise<void>;
 };
 
 export type CoreQuickMethods = {

--- a/src/types/builder/loyaltyProgram.ts
+++ b/src/types/builder/loyaltyProgram.ts
@@ -12,7 +12,7 @@ export type LoyaltyProgramIds = {
 };
 
 export type LoyaltyProgramNormalMethods = {
-  claimLoyaltyRevenue: (veScaKey: SuiObjectArg) => TransactionResult;
+  claimLoyaltyRevenue: (veScaKey: SuiObjectArg) => Promise<TransactionResult>;
 };
 
 export type LoyaltyProgramQuickMethods = {

--- a/src/types/builder/referral.ts
+++ b/src/types/builder/referral.ts
@@ -16,16 +16,18 @@ export type ReferralIds = {
 };
 
 export type ReferralNormalMethods = {
-  bindToReferral: (veScaKeyId: string) => void;
-  claimReferralTicket: (poolCoinName: SupportPoolCoins) => TransactionResult;
+  bindToReferral: (veScaKeyId: string) => Promise<void>;
+  claimReferralTicket: (
+    poolCoinName: SupportPoolCoins
+  ) => Promise<TransactionResult>;
   burnReferralTicket: (
     ticket: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => void;
+  ) => Promise<void>;
   claimReferralRevenue: (
     veScaKey: SuiObjectArg,
     poolCoinName: SupportPoolCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
 };
 
 export type ReferralQuickMethods = {

--- a/src/types/builder/sCoin.ts
+++ b/src/types/builder/sCoin.ts
@@ -21,7 +21,7 @@ export type sCoinNormalMethods = {
   mintSCoin: (
     marketCoinName: SupportSCoin,
     marketCoin: SuiObjectArg
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   /**
    * Burn sCoin and return marketCoin
    * @param sCoinName
@@ -31,7 +31,7 @@ export type sCoinNormalMethods = {
   burnSCoin: (
     sCoinName: SupportSCoin,
     sCoin: SuiObjectArg
-  ) => TransactionResult; // returns marketCoin
+  ) => Promise<TransactionResult>; // returns marketCoin
 };
 
 export type sCoinQuickMethods = {

--- a/src/types/builder/spool.ts
+++ b/src/types/builder/spool.ts
@@ -15,21 +15,21 @@ export type SpoolIds = {
 export type SpoolNormalMethods = {
   createStakeAccount: (
     stakeMarketCoinName: SupportStakeMarketCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   stake: (
     stakeAccount: SuiAddressArg,
     coin: SuiObjectArg,
     stakeMarketCoinName: SupportStakeMarketCoins
-  ) => void;
+  ) => Promise<void>;
   unstake: (
     stakeAccount: SuiAddressArg,
     amount: number,
     stakeMarketCoinName: SupportStakeMarketCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   claim: (
     stakeAccount: SuiAddressArg,
     stakeMarketCoinName: SupportStakeMarketCoins
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
 };
 
 export type SpoolQuickMethods = {

--- a/src/types/builder/vesca.ts
+++ b/src/types/builder/vesca.ts
@@ -13,19 +13,22 @@ export type VeScaNormalMethods = {
   lockSca: (
     scaCoin: SuiObjectArg,
     unlockAtInSecondTimestamp: number
-  ) => TransactionResult;
+  ) => Promise<TransactionResult>;
   extendLockPeriod: (
     veScaKey: SuiObjectArg,
     newUnlockAtInSecondTimestamp: number
-  ) => void;
-  extendLockAmount: (veScaKey: SuiObjectArg, scaCoin: SuiObjectArg) => void;
+  ) => Promise<void>;
+  extendLockAmount: (
+    veScaKey: SuiObjectArg,
+    scaCoin: SuiObjectArg
+  ) => Promise<void>;
   renewExpiredVeSca: (
     veScaKey: SuiObjectArg,
     scaCoin: SuiObjectArg,
     newUnlockAtInSecondTimestamp: number
-  ) => void;
-  redeemSca: (veScaKey: SuiObjectArg) => TransactionResult;
-  mintEmptyVeSca: () => TransactionResult;
+  ) => Promise<void>;
+  redeemSca: (veScaKey: SuiObjectArg) => Promise<TransactionResult>;
+  mintEmptyVeSca: () => Promise<TransactionResult>;
 };
 
 export type RedeemScaQuickReturnType<T extends boolean> = T extends true

--- a/src/types/query/core.ts
+++ b/src/types/query/core.ts
@@ -28,7 +28,7 @@ export type BalanceSheet = {
   revenue: string;
 };
 
-export type BorrowIndex = {
+export type BorrowDynamic = {
   borrow_index: string;
   interest_rate: {
     fields: {
@@ -38,6 +38,8 @@ export type BorrowIndex = {
   interest_rate_scale: string;
   last_updated: string;
 };
+
+export type BorrowFee = { value: string };
 
 export type InterestModel = {
   base_borrow_rate_per_sec: {
@@ -161,7 +163,7 @@ export type MarketCollateral = {
     | 'collateralFactor'
     | 'liquidationFactor'
     | 'liquidationDiscount'
-    | 'liquidationPanelty'
+    | 'liquidationPenalty'
     | 'liquidationReserveFactor'
   >
 > &
@@ -187,6 +189,9 @@ export type OriginMarketPoolData = {
   highKink: { value: string };
   midKink: { value: string };
   minBorrowAmount: string;
+  isIsolated: boolean;
+  supplyLimit: string;
+  borrowLimit: string;
 };
 
 export type ParsedMarketPoolData = {
@@ -209,6 +214,9 @@ export type ParsedMarketPoolData = {
   highKink: number;
   midKink: number;
   minBorrowAmount: number;
+  isIsolated: boolean;
+  supplyLimit: number;
+  borrowLimit: number;
 };
 
 export type CalculatedMarketPoolData = {
@@ -218,6 +226,8 @@ export type CalculatedMarketPoolData = {
   borrowApyOnHighKink: number;
   borrowAprOnMidKink: number;
   borrowApyOnMidKink: number;
+  coinDecimal: number;
+  conversionRate: number;
   maxBorrowApr: number;
   maxBorrowApy: number;
   borrowApr: number;
@@ -233,15 +243,18 @@ export type CalculatedMarketPoolData = {
   utilizationRate: number;
   supplyApr: number;
   supplyApy: number;
-  conversionRate: number;
+  isIsolated: boolean;
+  maxSupplyCoin: number;
+  maxBorrowCoin: number;
 };
 
 export type OriginMarketCollateralData = {
   type: { name: string };
+  isIsolated: boolean;
   collateralFactor: { value: string };
   liquidationFactor: { value: string };
   liquidationDiscount: { value: string };
-  liquidationPanelty: { value: string };
+  liquidationPenalty: { value: string };
   liquidationReserveFactor: { value: string };
   maxCollateralAmount: string;
   totalCollateralAmount: string;
@@ -252,13 +265,16 @@ export type ParsedMarketCollateralData = {
   collateralFactor: number;
   liquidationFactor: number;
   liquidationDiscount: number;
-  liquidationPanelty: number;
+  liquidationPenalty: number;
   liquidationReserveFactor: number;
   maxCollateralAmount: number;
   totalCollateralAmount: number;
+  isIsolated: boolean;
 };
 
 export type CalculatedMarketCollateralData = {
+  coinDecimal: number;
+  isIsolated: boolean;
   maxDepositAmount: number;
   maxDepositCoin: number;
   depositAmount: number;

--- a/src/types/query/spool.ts
+++ b/src/types/query/spool.ts
@@ -37,6 +37,27 @@ export type OriginSpoolData = {
   lastUpdate: string;
 };
 
+export type SpoolData = {
+  created_at: string;
+  distributed_point: string;
+  distributed_point_per_period: string;
+  id: {
+    id: string;
+  };
+  index: string;
+  last_update: string;
+  max_distributed_point: string;
+  max_stakes: string;
+  point_distribution_time: string;
+  stake_type: {
+    type: string;
+    fields: {
+      name: string;
+    };
+  };
+  stakes: string;
+};
+
 export type ParsedSpoolData = {
   stakeType: string;
   maxPoint: number;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -11,10 +11,15 @@ export type PoolAddressInfo = {
   coingeckoId: string;
   decimal: number;
   pythFeedId: string;
-  lendingPoolAddress: string;
-  collateralPoolAddress?: string;
+  lendingPoolAddress?: string;
+  collateralPoolAddress?: string; // not all pool has collateral
+  borrowDynamic?: string;
+  interestModelId?: string;
+  borrowFeeKey?: string;
+  supplyLimitKey?: string;
+  borrowLimitKey?: string;
+  isolatedAssetKey?: string;
   sCoinAddress: string | undefined;
   marketCoinAddress: string;
-  coinAddress: string;
   sCoinName: string | undefined;
 };

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1,0 +1,11 @@
+import { SuiObjectData } from '@mysten/sui/client';
+
+export const parseObjectAs = <T>(object: SuiObjectData): T => {
+  if (!(object && object.content && 'fields' in object.content))
+    throw new Error(`Failed to parse object`);
+
+  const value = (object.content.fields as any).value;
+  if (typeof value === 'object' && 'fields' in value)
+    return (object.content.fields as any).value.fields as T;
+  return value as T;
+};

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -4,8 +4,15 @@ export const parseObjectAs = <T>(object: SuiObjectData): T => {
   if (!(object && object.content && 'fields' in object.content))
     throw new Error(`Failed to parse object`);
 
-  const value = (object.content.fields as any).value;
-  if (typeof value === 'object' && 'fields' in value)
-    return (object.content.fields as any).value.fields as T;
-  return value as T;
+  const fields = object.content.fields as any;
+
+  if (typeof fields === 'object' && 'value' in fields) {
+    const value = fields.value;
+    if (typeof value === 'object' && 'fields' in value)
+      return value.fields as T;
+    return value as T;
+  } else if (typeof fields === 'object') {
+    return fields as T;
+  }
+  return fields as T;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './util';
 export * from './tokenBucket';
 export * from './indexer';
 export * from './core';
+export * from './tokenBucket';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './query';
 export * from './util';
 export * from './tokenBucket';
 export * from './indexer';
+export * from './core';

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -62,6 +62,9 @@ export const parseOriginMarketPoolData = (
     highKink: Number(originMarketPoolData.highKink.value) / 2 ** 32,
     midKink: Number(originMarketPoolData.midKink.value) / 2 ** 32,
     minBorrowAmount: Number(originMarketPoolData.minBorrowAmount),
+    isIsolated: originMarketPoolData.isIsolated,
+    supplyLimit: Number(originMarketPoolData.supplyLimit),
+    borrowLimit: Number(originMarketPoolData.borrowLimit),
   };
 };
 
@@ -142,6 +145,7 @@ export const calculateMarketPoolData = (
     borrowApyOnHighKink: utils.parseAprToApy(borrowAprOnHighKink),
     borrowAprOnMidKink,
     borrowApyOnMidKink: utils.parseAprToApy(borrowAprOnMidKink),
+    coinDecimal,
     maxBorrowApr,
     maxBorrowApy: utils.parseAprToApy(maxBorrowApr),
     borrowApr: Math.min(borrowApr, maxBorrowApr),
@@ -161,6 +165,13 @@ export const calculateMarketPoolData = (
     supplyApr: supplyApr.toNumber(),
     supplyApy: utils.parseAprToApy(supplyApr.toNumber()),
     conversionRate: conversionRate.toNumber(),
+    isIsolated: parsedMarketPoolData.isIsolated,
+    maxSupplyCoin: BigNumber(parsedMarketPoolData.supplyLimit)
+      .shiftedBy(coinDecimal)
+      .toNumber(),
+    maxBorrowCoin: BigNumber(parsedMarketPoolData.borrowLimit)
+      .shiftedBy(coinDecimal)
+      .toNumber(),
   };
 };
 
@@ -176,14 +187,15 @@ export const parseOriginMarketCollateralData = (
   const divisor = 2 ** 32;
   return {
     coinType: normalizeStructTag(originMarketCollateralData.type.name),
+    isIsolated: originMarketCollateralData.isIsolated,
     collateralFactor:
       Number(originMarketCollateralData.collateralFactor.value) / divisor,
     liquidationFactor:
       Number(originMarketCollateralData.liquidationFactor.value) / divisor,
     liquidationDiscount:
       Number(originMarketCollateralData.liquidationDiscount.value) / divisor,
-    liquidationPanelty:
-      Number(originMarketCollateralData.liquidationPanelty.value) / divisor,
+    liquidationPenalty:
+      Number(originMarketCollateralData.liquidationPenalty.value) / divisor,
     liquidationReserveFactor:
       Number(originMarketCollateralData.liquidationReserveFactor.value) /
       divisor,
@@ -212,6 +224,8 @@ export const calculateMarketCollateralData = (
   ).shiftedBy(-1 * coinDecimal);
 
   return {
+    coinDecimal,
+    isIsolated: parsedMarketCollateralData.isIsolated,
     maxDepositAmount: parsedMarketCollateralData.maxCollateralAmount,
     maxDepositCoin: maxCollateralCoin.toNumber(),
     depositAmount: parsedMarketCollateralData.totalCollateralAmount,

--- a/src/utils/tokenBucket.ts
+++ b/src/utils/tokenBucket.ts
@@ -42,7 +42,7 @@ const callWithRateLimit = async <T>(
   fn: () => Promise<T>,
   retryDelayInMs = DEFAULT_INTERVAL_IN_MS,
   maxRetries = 15,
-  backoffFactor = 2 // The factor by which to increase the delay
+  backoffFactor = 1.25 // The factor by which to increase the delay
 ): Promise<T | null> => {
   let retries = 0;
 
@@ -53,7 +53,7 @@ const callWithRateLimit = async <T>(
     } else if (retries < maxRetries) {
       retries++;
       const delay = retryDelayInMs * Math.pow(backoffFactor, retries);
-      console.error(`Rate limit exceeded, retrying in ${delay} ms`);
+      // console.error(`Rate limit exceeded, retrying in ${delay} ms`);
       await new Promise((resolve) => setTimeout(resolve, delay));
       return tryRequest();
     } else {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -127,3 +127,11 @@ export const findClosestUnlockRound = (unlockAtInSecondTimestamp: number) => {
   }
   return Math.floor(closestTwelveAM.getTime() / 1000);
 };
+
+export const partitionArray = <T>(array: T[], chunkSize: number) => {
+  const result: T[][] = [];
+  for (let i = 0; i < array.length; i += chunkSize) {
+    result.push(array.slice(i, i + chunkSize));
+  }
+  return result;
+};

--- a/test/builder.spec.ts
+++ b/test/builder.spec.ts
@@ -140,7 +140,10 @@ describe('Test Scallop Core Builder', async () => {
 
     const SUPPLY_COIN_NAME = 'wusdc';
     const FLASHLOAN_AMOUNT = 10 ** 5;
-    const [coin, loan] = tx.borrowFlashLoan(FLASHLOAN_AMOUNT, SUPPLY_COIN_NAME);
+    const [coin, loan] = await tx.borrowFlashLoan(
+      FLASHLOAN_AMOUNT,
+      SUPPLY_COIN_NAME
+    );
 
     const FLASHLOAN_FEE = Math.ceil(0.07 * FLASHLOAN_AMOUNT);
     const { takeCoin, leftCoin } = await scallopBuilder.selectCoin(
@@ -174,7 +177,7 @@ describe('Test Scallop Core Builder', async () => {
      */
     const suiTxBlock = tx.txBlock;
     const [coin] = suiTxBlock.splitCoins(suiTxBlock.gas, [10 ** 6]);
-    const marketCoin = tx.deposit(coin, SUPPLY_COIN_NAME);
+    const marketCoin = await tx.deposit(coin, SUPPLY_COIN_NAME);
     suiTxBlock.transferObjects([marketCoin], suiTxBlock.pure.address(sender));
     const txBlockResult = await scallopBuilder.suiKit.inspectTxn(tx);
     if (ENABLE_LOG) {
@@ -502,7 +505,7 @@ describe('Test Scallop VeSca Builder', async () => {
     const scaCoin = takeCoin;
     tx.transferObjects([leftCoin], sender);
 
-    const veScaKey = tx.lockSca(scaCoin, newUnlockAt);
+    const veScaKey = await tx.lockSca(scaCoin, newUnlockAt);
     // const lockPeriodInDays = 7; // lock for 1 day
     // const lockAmount = 10 * 10 ** 9;
     // await tx.renewExpiredVeScaQuick(
@@ -985,7 +988,7 @@ describe('Test Scallop Referral Builder', async () => {
   it('"claimReferralTicket" and "burnReferralTicket" should succeed', async () => {
     const tx = scallopBuilder.createTxBlock();
 
-    const ticket = tx.claimReferralTicket('sui');
+    const ticket = await tx.claimReferralTicket('sui');
     tx.burnReferralTicket(ticket, 'sui');
 
     const claimReferralTicketResult =

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -315,7 +315,8 @@ describe('Test Scallop Client - Other Method', async () => {
         stakeAccount.id
       );
     } else {
-      const stakeAccount = txBlock.createStakeAccount(stakeMarketCoinName);
+      const stakeAccount =
+        await txBlock.createStakeAccount(stakeMarketCoinName);
       await txBlock.stakeQuick(marketCoin, stakeMarketCoinName, stakeAccount);
       txBlock.transferObjects([stakeAccount], sender);
     }

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -12,14 +12,17 @@ const ENABLE_LOG = false;
 let _scallopQuery: ScallopQuery | null = null;
 const getScallopQuery = async () => {
   if (!_scallopQuery) {
-    _scallopQuery = await scallopSDK.createScallopQuery();
+    _scallopQuery = await scallopSDK.createScallopQuery({
+      walletAddress:
+        '0x61819c99588108d9f7710047e6ad8f2da598de8e98a26ea62bd7ad9847f5329c',
+    });
   }
   return _scallopQuery;
 };
 
 describe('Test Query Scallop Contract On Chain Data', async () => {
   const scallopQuery = await getScallopQuery();
-  console.info('Your wallet:', scallopQuery.suiKit.currentAddress());
+  console.info('Your wallet:', scallopQuery.walletAddress);
 
   it('Should query market data', async () => {
     const market = await scallopQuery.queryMarket();
@@ -259,7 +262,7 @@ describe('Test Query Borrow Incentive Contract On Chain Data', async () => {
 
 describe('Test Portfolio Query', async () => {
   const scallopQuery = await getScallopQuery();
-  console.info('Your wallet:', scallopQuery.suiKit.currentAddress());
+  console.info('Your wallet:', scallopQuery.walletAddress);
 
   it('Should get user lendings data', async () => {
     const lendings = await scallopQuery.getLendings(['sui', 'wusdc']);
@@ -297,8 +300,7 @@ describe('Test Portfolio Query', async () => {
     expect(obligations.length).toBeGreaterThan(0);
 
     const obligationAccount = await scallopQuery.getObligationAccount(
-      obligations[0].id,
-      scallopQuery.suiKit.currentAddress()
+      obligations[0].id
     );
     if (ENABLE_LOG) {
       console.info('Obligation account:');
@@ -318,7 +320,7 @@ describe('Test Portfolio Query', async () => {
 
 describe('Test VeSca Query', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   let obligationId: string | undefined;
@@ -412,7 +414,7 @@ describe('Test VeSca Query', async () => {
 
 describe('Test Referral Query', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   it(`Should get referrer veSCA key from a referee address`, async () => {
@@ -427,7 +429,7 @@ describe('Test Referral Query', async () => {
 
 describe('Test Loyalty Program Query', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   it(`Should get loyalty program information from a user address`, async () => {
@@ -449,7 +451,7 @@ describe('Test Loyalty Program Query', async () => {
 
 describe('Test sCoin Query', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   it('Should get total supply of sCoin', async () => {
@@ -479,7 +481,7 @@ describe('Test sCoin Query', async () => {
 
 describe('Test Supply Limit Query', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   it('Should get supply limit of a pool', async () => {
@@ -492,7 +494,7 @@ describe('Test Supply Limit Query', async () => {
 
 describe('Test Borrow Limit Query', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   it('Should get borrow limit of a pool', async () => {
@@ -505,7 +507,7 @@ describe('Test Borrow Limit Query', async () => {
 
 describe('Test Isolated Assets', async () => {
   const scallopQuery = await getScallopQuery();
-  const sender = scallopQuery.suiKit.currentAddress();
+  const sender = scallopQuery.walletAddress;
   console.info(`Your Wallet: ${sender}`);
 
   it.skip('Should return isolated assets', async () => {

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -508,7 +508,7 @@ describe('Test Isolated Assets', async () => {
   const sender = scallopQuery.suiKit.currentAddress();
   console.info(`Your Wallet: ${sender}`);
 
-  it('Should return isolated assets', async () => {
+  it.skip('Should return isolated assets', async () => {
     const isolatedAssets = await scallopQuery.getIsolatedAssets();
     expect(typeof isolatedAssets).toBe('object');
     expect(isolatedAssets.length > 0).toBe(true);


### PR DESCRIPTION
## OPTIMIZATION
Refactor objects fetching method by using `multiGetObjects` where possible, thus reduces rpc calls significantly

### TODOS
- [x] Optimize fetching all dynamic fields and table object inside market object
- [x] Optimize fetching spool pool, reward pool, treasury objects
- [ ] Optimize object in movecall args in scallopBuilder
- [ ] Optimize borrow incentive pool reward pools

#### WITHOUT OPTIMIZATION
![image](https://github.com/user-attachments/assets/10e1d664-80df-41ca-9c2a-731b2987cb55)


#### WITH OPTIMIZATION
![image](https://github.com/user-attachments/assets/e2a4afee-8491-40f1-b153-77f9feb050e7)

#### Preview Page
https://sui-scallop-dapp-git-refactor-optimize-scallop-team.vercel.app/
