### PR TITLE
Fix/minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.6](https://github.com/scallop-io/sui-scallop-sdk/compare/v2.0.5...v2.0.6) (2025-03-23)
+
+### Features
+
+- add `selectSCoinOrMarketCoin` function and use it on `withdrawQuick` ([e888676](https://github.com/scallop-io/sui-scallop-sdk/commit/e8886766ab865331e9a9467f27653c79c85413ac))
+
+### Bugfixes
+
+- fix `coinNameToOldMarketCoinTypeMap` logic ([0384be0](https://github.com/scallop-io/sui-scallop-sdk/commit/0384be08d764c9d3a5a0f9c41ea83d0a887385ff))
+- scallop cache init param ([87b4869](https://github.com/scallop-io/sui-scallop-sdk/commit/87b4869f063887168c9a1cbe35e95d8f95d5ae12))
+
 ### [2.0.5](https://github.com/scallop-io/sui-scallop-sdk/compare/v2.0.4...v2.0.5) (2025-03-21)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/builders/sCoinBuilder.ts
+++ b/src/builders/sCoinBuilder.ts
@@ -61,7 +61,7 @@ const generateSCoinQuickMethod: GenerateSCoinQuickMethod = ({
       );
 
       txBlock.transferObjects([leftCoin], sender);
-      return await txBlock.mintSCoin(marketCoinName, takeCoin);
+      return txBlock.mintSCoin(marketCoinName, takeCoin);
     },
     burnSCoinQuick: async (sCoinName, amount) => {
       const sender = requireSender(txBlock);
@@ -73,7 +73,7 @@ const generateSCoinQuickMethod: GenerateSCoinQuickMethod = ({
       );
 
       txBlock.transferObjects([leftCoin], sender);
-      return await txBlock.burnSCoin(sCoinName, takeCoin);
+      return txBlock.burnSCoin(sCoinName, takeCoin);
     },
   };
 };

--- a/src/models/scallopCache.ts
+++ b/src/models/scallopCache.ts
@@ -82,7 +82,7 @@ export class ScallopCache {
   private lastRefill: number;
 
   public constructor(
-    params: ScallopCacheParams,
+    params: ScallopCacheParams = {},
     instance?: ScallopCacheInstanceParams
   ) {
     this.params = params;

--- a/src/models/scallopConstants.ts
+++ b/src/models/scallopConstants.ts
@@ -210,7 +210,7 @@ export class ScallopConstants {
     if (this.isEmptyObject(this._coinNameToOldMarketCoinTypeMap))
       this._coinNameToOldMarketCoinTypeMap = Object.fromEntries(
         Object.entries(this.poolAddresses)
-          .filter(([_, value]) => !!value && value.spool)
+          .filter(([_, value]) => !!value)
           .map(([_, value]) => [
             value!.coinName,
             this.parseToOldMarketCoin(value!.coinType),


### PR DESCRIPTION
### Features

- add `selectSCoinOrMarketCoin` function and use it on `withdrawQuick` ([e888676](https://github.com/scallop-io/sui-scallop-sdk/commit/e8886766ab865331e9a9467f27653c79c85413ac))

### Bugfixes
- fix `coinNameToOldMarketCoinTypeMap` logic ([0384be0](https://github.com/scallop-io/sui-scallop-sdk/commit/0384be08d764c9d3a5a0f9c41ea83d0a887385ff))
- scallop cache init param ([87b4869](https://github.com/scallop-io/sui-scallop-sdk/commit/87b4869f063887168c9a1cbe35e95d8f95d5ae12))