### PR TITLE
feat: add default values for scallop constants in case api error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.1.6](https://github.com/scallop-io/sui-scallop-sdk/compare/v2.1.6...v2.1.7) (2025-05-23)
+
+- Add default values for addresses, pool addresses and whitelist API ([b17eb59](https://github.com/scallop-io/sui-scallop-sdk/pull/260/commits/b17eb596a67124d6102c2ee848b65ad6390b98b7))([62aeef1](https://github.com/scallop-io/sui-scallop-sdk/pull/260/commits/62aeef1b0618ab516befc4832da463f4d11b5384))([8a85667](https://github.com/scallop-io/sui-scallop-sdk/pull/260/commits/8a8566791d9063e31b01406ae5a4ac4dfc3603ea))
+
 ### [2.1.6](https://github.com/scallop-io/sui-scallop-sdk/compare/v2.1.5...v2.1.6) (2025-05-09)
 
 - Minor fix ([1464074](https://github.com/scallop-io/sui-scallop-sdk/pull/245/commits/1464074dce10fa69421c4f7f301f2b04d7f9aed0))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",
@@ -62,7 +62,7 @@
     "@mysten/sui": "1.28.2",
     "@pythnetwork/pyth-sui-js": "2.1.0",
     "@scallop-io/sui-kit": "1.4.0",
-    "@tanstack/query-core": "5.51.15",
+    "@tanstack/query-core": "5.59.16",
     "axios": "^1.9.0",
     "bignumber.js": "^9.1.2",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0(typescript@5.5.4)
       '@tanstack/query-core':
-        specifier: 5.51.15
-        version: 5.51.15
+        specifier: 5.59.16
+        version: 5.59.16
       axios:
         specifier: ^1.9.0
         version: 1.9.0
@@ -821,8 +821,8 @@ packages:
   '@shikijs/core@1.11.1':
     resolution: {integrity: sha512-Qsn8h15SWgv5TDRoDmiHNzdQO2BxDe86Yq6vIHf5T0cCvmfmccJKIzHtep8bQO9HMBZYCtCBzaXdd1MnxZBPSg==}
 
-  '@tanstack/query-core@5.51.15':
-    resolution: {integrity: sha512-xyobHDJ0yhPE3+UkSQ2/4X1fLSg7ICJI5J1JyU9yf7F3deQfEwSImCDrB1WSRrauJkMtXW7YIEcC0oA6ZZWt5A==}
+  '@tanstack/query-core@5.59.16':
+    resolution: {integrity: sha512-crHn+G3ltqb5JG0oUv6q+PMz1m1YkjpASrXTU+sYWW9pLk0t2GybUHNRqYPZWhxgjPaVGC4yp92gSFEJgYEsPw==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -3860,7 +3860,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  '@tanstack/query-core@5.51.15': {}
+  '@tanstack/query-core@5.59.16': {}
 
   '@types/estree@1.0.5': {}
 

--- a/src/models/scallopAddress.ts
+++ b/src/models/scallopAddress.ts
@@ -687,7 +687,7 @@ class ScallopAddress {
     if (addressId !== undefined) {
       const response = await (async () => {
         try {
-          return this.readApi<
+          return await this.readApi<
             Record<NetworkType, AddressesInterface> & { id?: string }
           >({
             url: `/addresses/${addressId}`,

--- a/src/models/scallopConstants.ts
+++ b/src/models/scallopConstants.ts
@@ -326,7 +326,7 @@ class ScallopConstants extends ScallopAddress {
   async readWhiteList() {
     const response = await (async () => {
       try {
-        return this.readApi<Record<keyof Whitelist, string[]>>({
+        return await this.readApi<Record<keyof Whitelist, string[]>>({
           url:
             this.params.whitelistApiUrl ??
             `https://sui.apis.scallop.io/pool/whitelist`,

--- a/src/models/scallopConstants.ts
+++ b/src/models/scallopConstants.ts
@@ -1,9 +1,7 @@
-import { AddressesInterface, PoolAddress, Whitelist } from 'src/types';
+import { PoolAddress, Whitelist } from 'src/types';
 import ScallopAddress, { ScallopAddressParams } from './scallopAddress';
 import { NetworkType, parseStructTag } from '@scallop-io/sui-kit';
-import ScallopAxios from './scallopAxios';
 import { queryKeys } from 'src/constants';
-import { QueryKey } from '@tanstack/query-core';
 
 const isEmptyObject = (obj: object) => {
   return Object.keys(obj).length === 0;
@@ -30,7 +28,6 @@ export type ScallopConstantsParams = {
   forcePoolAddressInterface?: Record<string, PoolAddress>;
   forceWhitelistInterface?: Whitelist | Record<string, any>;
   defaultValues?: {
-    address?: Partial<Record<NetworkType, AddressesInterface>>;
     poolAddresses?: Record<string, PoolAddress>;
     whitelist?: Whitelist | Record<string, any>;
   };
@@ -106,11 +103,8 @@ class ScallopConstants extends ScallopAddress {
    */
   public supportedBorrowIncentiveRewards: Set<CoinName> = new Set();
 
-  private scallopConstantAxios: ScallopAxios;
-
   constructor(public readonly params: ScallopConstantsParams = {}) {
     super(params);
-    this.scallopConstantAxios = new ScallopAxios();
   }
 
   get protocolObjectId() {
@@ -327,23 +321,6 @@ class ScallopConstants extends ScallopAddress {
         .map((t) => (t.sCoinName ? [t.coinName, t.sCoinName] : [t.coinName]))
         .flat(),
     ]);
-  }
-
-  private async readApi<T>({
-    url,
-    queryKey,
-  }: {
-    url: string;
-    queryKey: QueryKey;
-  }) {
-    const resp = await this.scallopConstantAxios.get<T>(url, queryKey);
-    if (resp.status === 200) {
-      return resp.data as T;
-    } else {
-      throw Error(
-        `Error: ${resp.status}; Failed to read ${url} ${resp.statusText}`
-      );
-    }
   }
 
   async readWhiteList() {

--- a/src/types/address.ts
+++ b/src/types/address.ts
@@ -1,6 +1,7 @@
 import { _SUPPORT_ORACLES, SupportOracleType } from './constant/xOracle';
 
 export interface AddressesInterface {
+  id?: string;
   core: {
     version: string;
     versionCap: string;

--- a/test/constants.spec.ts
+++ b/test/constants.spec.ts
@@ -50,7 +50,7 @@ describe('Test Scallop Constants default values', () => {
       defaultValues: {
         poolAddresses: POOL_ADDRESSES,
         whitelist: WHITELIST,
-        address: { mainnet: TEST_ADDRESSES },
+        addresses: { mainnet: TEST_ADDRESSES },
       },
     });
 
@@ -67,8 +67,6 @@ describe('Test Scallop Constants default values', () => {
     expect(Object.values(localScallopConstants.poolAddresses).length > 0).toBe(
       true
     );
-    expect(
-      Object.values(localScallopConstants.getAddresses() ?? {}).length > 0
-    ).toBe(true);
+    expect(localScallopConstants.getAddresses()?.core.version).not.toBe('');
   });
 });

--- a/test/constants.spec.ts
+++ b/test/constants.spec.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  POOL_ADDRESSES,
+  ScallopConstants,
+  TEST_ADDRESSES,
+  WHITELIST,
+  Whitelist,
+} from 'src';
 import { scallopSDK } from './scallopSdk';
-import { ScallopConstants, Whitelist } from 'src';
 
 // const ENABLE_LOG = false;
 let scallopConstants: ScallopConstants;
 beforeAll(async () => {
   scallopConstants = await scallopSDK.getScallopConstants();
-  await scallopConstants.init();
 });
 
 describe('Test Scallop Constants API Fetch', () => {
@@ -35,5 +40,35 @@ describe('Test Scallop Constants Values Overide', () => {
     expect(Object.values(scallopConstants.poolAddresses).length === 0).toBe(
       true
     );
+  });
+});
+
+describe('Test Scallop Constants default values', () => {
+  it('Should use default values when readApi is not available', async () => {
+    const localScallopConstants = new ScallopConstants({
+      addressId: '67c44a103fe1b8c454eb9699',
+      defaultValues: {
+        poolAddresses: POOL_ADDRESSES,
+        whitelist: WHITELIST,
+        address: { mainnet: TEST_ADDRESSES },
+      },
+    });
+
+    expect(localScallopConstants.whitelist.lending.size).toBe(0);
+    expect(Object.values(localScallopConstants.poolAddresses).length).toBe(0);
+    expect(localScallopConstants.getAddresses()).toBe(undefined);
+
+    localScallopConstants['readApi'] = () => {
+      throw new Error('Intentional Error');
+    };
+
+    await localScallopConstants.init();
+    expect(localScallopConstants.whitelist.lending.size > 0).toBe(true);
+    expect(Object.values(localScallopConstants.poolAddresses).length > 0).toBe(
+      true
+    );
+    expect(
+      Object.values(localScallopConstants.getAddresses() ?? {}).length > 0
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
### CHANGES
- Add default values for scallop constants in case API fetch encounters error ([b17eb59](https://github.com/scallop-io/sui-scallop-sdk/pull/260/commits/b17eb596a67124d6102c2ee848b65ad6390b98b7))