### PR TITLE
fix: bug for migration to mysten/sui-kit v2

### DIFF
--- a/src/models/scallopSuiKit.ts
+++ b/src/models/scallopSuiKit.ts
@@ -299,22 +299,36 @@ class ScallopSuiKit extends ScallopQueryClient {
     // v2: Convert { type, value } to { type, bcs }
     const nameParam = encodeDynamicFieldNameForV2(input.name);
 
+    // v2: getDynamicField throws an error with "not found" when the field doesn't exist (v1 returned null).
+    const isNotFound = (e: unknown) =>
+      (e instanceof Error ? e.message : String(e))
+        .toLowerCase()
+        .includes('not found');
+
     const result = await this.callWithRateLimiter(
       queryKeys.rpc.getDynamicFieldObject(input),
       async () => {
-        const { dynamicField } = await this.client.core.getDynamicField({
-          parentId: input.parentId,
-          name: nameParam,
-        });
-        return await this.client.core.getObject({
-          objectId: dynamicField.fieldId,
-          include: {
-            content: true,
-            json: true,
-          },
-        });
+        try {
+          const { dynamicField } = await this.client.core.getDynamicField({
+            parentId: input.parentId,
+            name: nameParam,
+          });
+          return await this.client.core.getObject({
+            objectId: dynamicField.fieldId,
+            include: {
+              content: true,
+              json: true,
+            },
+          });
+        } catch (e: unknown) {
+          if (isNotFound(e)) return null;
+          throw e;
+        }
       }
-    );
+    ).catch((e: unknown) => {
+      if (isNotFound(e)) return null as SuiObjectResponse | null;
+      throw e;
+    });
 
     if (result?.object) {
       const queryKey = queryKeys.rpc.getObject({

--- a/src/models/scallopUtils.ts
+++ b/src/models/scallopUtils.ts
@@ -426,14 +426,13 @@ class ScallopUtils implements ScallopUtilsInterface {
       priceFeedObject ||
       (await this.scallopSuiKit.queryGetObject(pythFeedObjectId))?.object;
 
-    if (priceFeedObject?.content && 'fields' in priceFeedObject.content) {
-      const fields = priceFeedObject.content.fields as any;
-      const priceFields =
-        fields?.price_info?.fields?.price_feed?.fields?.price?.fields;
-      const expoMagnitude = Number(priceFields?.expo?.fields?.magnitude);
-      const expoNegative = Number(priceFields?.expo?.fields?.negative);
-      const priceMagnitude = Number(priceFields?.price?.fields?.magnitude);
-      const priceNegative = Number(priceFields?.price?.fields?.negative);
+    if (priceFeedObject?.json) {
+      const json = priceFeedObject.json as any;
+      const priceFields = json?.price_info?.price_feed?.price;
+      const expoMagnitude = Number(priceFields?.expo?.magnitude);
+      const expoNegative = Number(priceFields?.expo?.negative);
+      const priceMagnitude = Number(priceFields?.price?.magnitude);
+      const priceNegative = Number(priceFields?.price?.negative);
 
       if (!Number.isNaN(expoMagnitude) && !Number.isNaN(priceMagnitude)) {
         const price =

--- a/src/queries/borrowIncentiveQuery.ts
+++ b/src/queries/borrowIncentiveQuery.ts
@@ -320,7 +320,7 @@ export const getBindedVeScaKey = async (
     parseObjectAs<Record<string, unknown>>(
       incentiveAccountsObject.object
     ) as any
-  ).accounts.fields.id.id;
+  ).accounts.id;
 
   // Search in the table
   const bindedIncentiveAcc = await scallopSuiKit.queryGetDynamicFieldObject({
@@ -336,7 +336,5 @@ export const getBindedVeScaKey = async (
     bindedIncentiveAcc.object
   ) as any;
 
-  return (
-    bindedIncentiveAccFields.value.fields.binded_ve_sca_key?.fields.id ?? null
-  );
+  return bindedIncentiveAccFields.binded_ve_sca_key?.id ?? null;
 };

--- a/src/queries/loyaltyProgramQuery.ts
+++ b/src/queries/loyaltyProgramQuery.ts
@@ -20,10 +20,8 @@ const rewardPoolFieldsZod = zod
   }));
 
 const userRewardFieldsZod = zod
-  .object({
-    value: zod.string(),
-  })
-  .transform((value) => BigNumber(value.value).shiftedBy(-9).toNumber());
+  .string()
+  .transform((value) => BigNumber(value).shiftedBy(-9).toNumber());
 
 type RewardPoolFields = zod.infer<typeof rewardPoolFieldsZod>;
 type UserRewardFields = zod.infer<typeof userRewardFieldsZod>;
@@ -77,7 +75,7 @@ export const getLoyaltyProgramInformations = async (
 
   const userRewardObjData = userRewardObject?.object;
   if (!userRewardObjData) return result;
-  const userRewardFields = parseObjectAs<{ value: string }>(userRewardObjData);
+  const userRewardFields = parseObjectAs<string>(userRewardObjData);
   result.pendingReward = userRewardFieldsZod.parse(
     userRewardFields
   ) as UserRewardFields;

--- a/src/queries/vescaQuery.ts
+++ b/src/queries/vescaQuery.ts
@@ -241,9 +241,14 @@ const getTotalVeScaTreasuryAmount = async (
   txb.moveCall(refreshQueryTarget, resolvedRefreshArgs);
   txb.moveCall(veScaAmountQueryTarget, resolvedVeScaAmountArgs);
 
+  const sender =
+    utils.suiKit.currentAddress ||
+    '0x0000000000000000000000000000000000000000000000000000000000000000';
+  txb.txBlock.setSender(sender);
+  txb.txBlock.setGasBudget(50_000_000_000n);
+  txb.txBlock.setGasPayment([]);
   const txBytes = await txb.txBlock.build({
     client: utils.suiKit.client,
-    onlyTransactionKind: true,
   });
 
   // return result
@@ -294,10 +299,7 @@ export const getVeScaTreasuryInfo = async (
   const treasuryFields =
     parseObjectAs<VeScaTreasuryFields>(veScaTreasuryObject);
   const lockedScaAmount =
-    (treasuryFields as any)?.unlock_schedule?.fields?.locked_sca_amount ??
-    (treasuryFields as any)?.unlockSchedule?.lockedScaAmount ??
-    (treasuryFields as any)?.locked_sca_amount ??
-    '0';
+    (treasuryFields as any)?.unlock_schedule?.locked_sca_amount ?? '0';
 
   const totalLockedSca = BigNumber(lockedScaAmount).shiftedBy(-9).toNumber();
   const totalVeSca = BigNumber(

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -350,24 +350,22 @@ describe('Test VeSca Query', () => {
     expect(!!bindedObligationId).toBe(true);
   });
 
-  if (obligationId) {
-    it(`Should get veScaKeyId of obligationId ${obligationId}`, async () => {
-      if (!obligationId) {
-        throw new Error('No obligationId found');
-      }
-      const bindedVeScaKeyId = await scallopQuery.getBindedVeScaKey(
-        obligationId!
-      );
+  it(`Should get veScaKeyId of obligationId ${obligationId}`, async () => {
+    if (!obligationId) {
+      return;
+    }
+    const bindedVeScaKeyId = await scallopQuery.getBindedVeScaKey(
+      obligationId!
+    );
 
-      if (ENABLE_LOG) {
-        console.info('Binded VeSca Key Id:', bindedVeScaKeyId);
-      }
+    if (ENABLE_LOG) {
+      console.info('Binded VeSca Key Id:', bindedVeScaKeyId);
+    }
 
-      expect(!!bindedVeScaKeyId).toBe(true);
-    });
-  }
+    expect(bindedVeScaKeyId).toBeTruthy();
+  });
 
-  it.only(`Should get veSCA treasury info`, async () => {
+  it(`Should get veSCA treasury info`, async () => {
     const totalVeScaTreasury = await scallopQuery.getVeScaTreasuryInfo();
     if (ENABLE_LOG) {
       console.info('Total VeSca Treasury:', totalVeScaTreasury);

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -367,18 +367,23 @@ describe('Test VeSca Query', () => {
     });
   }
 
-  it(`Should get veSCA treasury info`, async () => {
+  it.only(`Should get veSCA treasury info`, async () => {
     const totalVeScaTreasury = await scallopQuery.getVeScaTreasuryInfo();
     if (ENABLE_LOG) {
       console.info('Total VeSca Treasury:', totalVeScaTreasury);
     }
+
     const treasuryInfoSchema = zod.object({
       totalLockedSca: zod.number(),
       totalVeSca: zod.number(),
       averageLockingPeriod: zod.number(),
       averageLockingPeriodUnit: zod.string(),
     });
-    expect(treasuryInfoSchema.safeParse(totalVeScaTreasury).success).toBe(true);
+    const { success, data } = treasuryInfoSchema.safeParse(totalVeScaTreasury);
+    expect(success).toBe(true);
+    expect(data).toBeTruthy();
+    expect(data?.totalLockedSca).toBeGreaterThan(0);
+    expect(data?.totalVeSca).toBeGreaterThan(0);
   });
 
   it(`Should get veSCA`, async () => {

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -4,6 +4,7 @@ import { z as zod } from 'zod';
 import { scallopSDK } from './scallopSdk.js';
 import { ScallopQuery } from 'src/models/index.js';
 import { BigNumber } from 'bignumber.js';
+import { parseObjectAs } from 'src/utils/index.js';
 
 const ENABLE_LOG = false;
 let obligationId: string | null;
@@ -254,6 +255,50 @@ describe('Test Query Borrow Incentive Contract On Chain Data', () => {
     }
     expect(!!borrowIncentiveAccounts).toBe(true);
   });
+
+  it('Should return null for an unbound obligationId', async () => {
+    const missingObligationId =
+      '0x0000000000000000000000000000000000000000000000000000000000000000';
+    const bindedVeScaKeyId =
+      await scallopQuery.getBindedVeScaKey(missingObligationId);
+    expect(bindedVeScaKeyId).toBeNull();
+  });
+
+  it('Should return null for a missing dynamic field object', async () => {
+    const incentiveAccountsId = scallopQuery.utils.address.get(
+      'borrowIncentive.incentiveAccounts'
+    );
+    const incentiveAccountsObject =
+      await scallopQuery.utils.scallopSuiKit.queryGetObject(
+        incentiveAccountsId
+      );
+    expect(incentiveAccountsObject?.object).toBeTruthy();
+    if (!incentiveAccountsObject?.object) return;
+
+    const incentiveAccountsTableId = (
+      parseObjectAs<Record<string, unknown>>(
+        incentiveAccountsObject.object
+      ) as any
+    ).accounts.id;
+
+    const borrowIncentiveObjectId = scallopQuery.utils.address.get(
+      'borrowIncentive.object'
+    );
+    const corePkg = scallopQuery.utils.address.get('core.object');
+    const missingObligationId =
+      '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+    const result =
+      await scallopQuery.utils.scallopSuiKit.queryGetDynamicFieldObject({
+        parentId: incentiveAccountsTableId,
+        name: {
+          type: `${borrowIncentiveObjectId}::typed_id::TypedID<${corePkg}::obligation::Obligation>`,
+          value: missingObligationId,
+        },
+      });
+
+    expect(result).toBeNull();
+  });
 });
 
 describe('Test Portfolio Query', () => {
@@ -363,6 +408,7 @@ describe('Test VeSca Query', () => {
     }
 
     expect(bindedVeScaKeyId).toBeTruthy();
+    expect(bindedVeScaKeyId).toBe(VE_SCA_KEY);
   });
 
   it(`Should get veSCA treasury info`, async () => {
@@ -446,6 +492,36 @@ describe('Test Loyalty Program Query', () => {
     expect(!!loyaltyProgramInfo).toBe(true);
     expect(loyaltyProgramInfoZod.safeParse(loyaltyProgramInfo).success).toBe(
       true
+    );
+  });
+
+  it(`Should parse pendingReward from raw user reward object`, async () => {
+    const userRewardTableId = scallopQuery.utils.address.get(
+      'loyaltyProgram.userRewardTableId'
+    );
+    const rawUserRewardObject =
+      await scallopQuery.utils.scallopSuiKit.queryGetDynamicFieldObject({
+        parentId: userRewardTableId,
+        name: {
+          type: '0x2::object::ID',
+          value: VE_SCA_KEY,
+        },
+      });
+
+    const loyaltyProgramInfo =
+      await scallopQuery.getLoyaltyProgramInfos(VE_SCA_KEY);
+    expect(loyaltyProgramInfo).toBeTruthy();
+
+    if (!rawUserRewardObject?.object) {
+      expect(loyaltyProgramInfo?.pendingReward ?? 0).toBeGreaterThanOrEqual(0);
+      return;
+    }
+
+    const rawValue = parseObjectAs<string>(rawUserRewardObject.object);
+    const expectedPendingReward = BigNumber(rawValue).shiftedBy(-9).toNumber();
+    expect(loyaltyProgramInfo?.pendingReward).toBeCloseTo(
+      expectedPendingReward,
+      8
     );
   });
 


### PR DESCRIPTION
### Summary

  This PR adds follow-up fixes for the Sui v2 migration branch.

  #### What changed

  - Fixed borrowIncentiveQuery to correctly access binded_ve_sca_key.
  - Updated vescaQuery transaction setup to explicitly set sender and gas budget.
  - Improved price field handling in scallopUtils for more robust parsing.
  - `userRewardFieldsZod` zod schema for loyalty program query.