### PR TITLE
docs(sdk): fix doc script entry and document referral/loyalty/borrow-incentive surface

### DIFF
--- a/docs/SDK_STRUCTURE.md
+++ b/docs/SDK_STRUCTURE.md
@@ -3,7 +3,6 @@
 A guided tour of how `@scallop-io/sui-scallop-sdk` is laid out. Read this first if you're new to the codebase or returning after a long break.
 
 > **Audience:** SDK contributors and integrators who want to understand the moving parts without reading every file.
-> **Companion docs:** [`SDK_STRUCTURE_REPORT.md`](SDK_STRUCTURE_REPORT.md) (problem statement) and [`SDK_STRUCTURE_FIX_PLAN.md`](SDK_STRUCTURE_FIX_PLAN.md) (workstreams + status). The read layer has its own contributor guide in [`../src/repositories/CLAUDE.md`](../src/repositories/CLAUDE.md).
 
 ---
 

--- a/document/builder.md
+++ b/document/builder.md
@@ -327,6 +327,106 @@ const scallopTxBlock = scallopBuilder.createTxBlock();
   await scallopTxBlock.burnSCoinQuick(sCoinName, 10 ** 9);
   ```
 
+## Organize transactions that interact with borrow incentive
+
+- Stake an obligation into the borrow incentive program.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  // Obligation id/key are auto-detected from the sender when omitted.
+  await scallopTxBlock.stakeObligationQuick();
+  // Stake while binding a veSCA key for a boosted rate.
+  await scallopTxBlock.stakeObligationWithVeScaQuick(
+    obligationId,
+    obligationKey,
+    veScaKey
+  );
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+- Unstake an obligation from the borrow incentive program.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  await scallopTxBlock.unstakeObligationQuick();
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+- Claim borrow incentive rewards.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  const rewardCoin = await scallopTxBlock.claimBorrowIncentiveQuick(
+    'sui',
+    obligationId,
+    obligationKey
+  );
+  scallopTxBlock.transferObjects([rewardCoin], sender);
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+## Organize transactions that interact with referral
+
+- Bind the sender to a referrer's veSCA key.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  scallopTxBlock.bindToReferral(referrerVeScaKeyId);
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+- Claim accrued referral revenue.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  // coinNames defaults to the lending whitelist when omitted.
+  await scallopTxBlock.claimReferralRevenueQuick(veScaKey, ['sui', 'wusdc']);
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+- Burn a referral ticket.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  scallopTxBlock.burnReferralTicket(ticket, 'sui');
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+## Organize transactions that interact with loyalty program
+
+- Claim loyalty program SCA revenue.
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  // veScaKey defaults to the sender's first veSCA account when omitted.
+  await scallopTxBlock.claimLoyaltyRevenueQuick(veScaKey);
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
+- Claim veSCA loyalty program reward (a new veSCA key).
+
+  ```typescript
+  const scallopTxBlock = scallopBuilder.createTxBlock();
+  scallopTxBlock.setSender(sender);
+
+  await scallopTxBlock.claimVeScaLoyaltyRewardQuick(veScaKey);
+  await scallopBuilder.signAndSendTxBlock(scallopTxBlock);
+  ```
+
 ## Organize transactions that name obligations
 
 The obligation-naming methods attach a human-readable name to an obligation

--- a/document/client.md
+++ b/document/client.md
@@ -165,6 +165,76 @@ Methods for interacting with the spool contract.
   const claimResult = await client.claim('ssui');
   ```
 
+## Referral Interaction Method
+
+Methods for interacting with the referral contract, reachable via `client.referralService`.
+
+- Bind a wallet to a referrer's veSCA key.
+
+  ```typescript
+  // Binds the signer to the referrer identified by their veSCA key id.
+  const bindResult = await client.referralService.bindToReferral(veScaKeyId);
+  ```
+
+- Claim referral revenue.
+
+  ```typescript
+  // Claims accrued referral revenue for the given veSCA key.
+  // When coinNames is omitted, it defaults to the lending whitelist.
+  const claimResult = await client.referralService.claimReferralRevenue(
+    veScaKey,
+    ['sui', 'wusdc']
+  );
+  ```
+
+- Burn a referral ticket.
+
+  ```typescript
+  // Burns a referral ticket for the given pool coin.
+  const burnResult = await client.referralService.burnReferralTicket(
+    ticket,
+    'sui'
+  );
+  ```
+
+## Borrow Incentive Method
+
+Methods for interacting with the borrow incentive contract.
+
+- Stake / unstake an obligation to earn borrow incentives.
+
+  ```typescript
+  // Requires the obligation id and key.
+  const obligationsData = await client.query.getObligations();
+  const stakeResult = await client.stakeObligation(
+    obligationsData[0].id,
+    obligationsData[0].keyId
+  );
+  // Unstake it again.
+  const unstakeResult = await client.unstakeObligation(
+    obligationsData[0].id,
+    obligationsData[0].keyId
+  );
+  ```
+
+- Claim borrow incentive rewards.
+
+  ```typescript
+  // Claims every reward coin with an available claim amount on the obligation.
+  const obligationsData = await client.query.getObligations();
+  const claimBorrowIncentiveResult = await client.claimBorrowIncentive(
+    obligationsData[0].id,
+    obligationsData[0].keyId
+  );
+  ```
+
+- Claim all unlocked SCA from expired veSCA accounts.
+
+  ```typescript
+  // Claim unlocked SCA from all of the sender's veSCA accounts.
+  const claimAllUnlockedScaResult = await client.claimAllUnlockedSca();
+  ```
+
 ## New sCoin Package Migration Method
 
 Methods for migrating to the new sCoin package

--- a/document/query.md
+++ b/document/query.md
@@ -109,6 +109,15 @@
   );
   ```
 
+- Get the on-chain names registered for an address's obligations.
+
+  ```typescript
+  const scallopQuery = await scallopSDK.createScallopQuery();
+
+  // Map of obligation id to its registered name (unnamed obligations are omitted).
+  const obligationNames = await scallopQuery.getObligationNames();
+  ```
+
 - Get TVL.
 
   ```typescript

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "release:major": "standard-version -r major",
     "release:minor": "standard-version -r minor",
     "release:patch": "standard-version -r patch",
-    "doc": "typedoc --out docs src/index.ts"
+    "doc": "typedoc --out docs --cleanOutputDir false src/entries/index.ts"
   },
   "dependencies": {
     "@noble/hashes": "^2.2.0",


### PR DESCRIPTION
## What

- Fix `pnpm run doc`: entry pointed at the deleted `src/index.ts` → now `src/entries/index.ts` (matches `tsup.config.ts`), plus `--cleanOutputDir false` so typedoc stops wiping the hand-written markdown under `docs/` on each run.
- Remove dead links in `docs/SDK_STRUCTURE.md` (pointed at `SDK_STRUCTURE_REPORT.md`, `SDK_STRUCTURE_FIX_PLAN.md`, `../src/repositories/CLAUDE.md` — none exist in the repo).
- Document the referral / loyalty / borrow-incentive surface that was missing, aligned to the actual v4.3.0 exports:
  - `document/client.md`: Referral + Borrow Incentive methods
  - `document/builder.md`: `tx.referral`, `tx.loyalty`, `tx.borrowIncentive`
  - `document/query.md`: `getObligationNames`

## Verification

`pnpm install && pnpm run build && pnpm run test:typecheck && pnpm run doc` — all green. Dead-link strings confirmed gone via grep. Every documented method checked against actual `src/` exports.

## For reviewer

- `--cleanOutputDir false` in the `doc` script is necessary (without it typedoc deletes tracked markdown), but flagging since it's slightly beyond a one-line entry fix. Alternative: point typedoc output at `docs/api/`.
- `client.md` intentionally has no Loyalty section — v4.3.0 has no loyalty methods at the client layer (only builder/query). Client-layer loyalty helpers would be a product gap (new `LoyaltyService`), not a docs gap; no `src/` touched.
- Task mentioned `getObligationName` (singular) — no such export exists, only `getObligationNames`. Documented the real one only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
