### PR TITLE
Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.2.5](https://github.com/scallop-io/sui-scallop-sdk/compare/v5.2.4...v5.2.5) (2026-08-01)
+
+### Fixed
+
+- The borrow-incentive pool query used the raw on-chain `pool_type` field (which can be an object) instead of the parsed pool type, and silently dropped point updates once a reward campaign was exhausted instead of still emitting the accrued points with a zeroed APR ([c5d68c0](https://github.com/scallop-io/sui-scallop-sdk/commit/c5d68c08584a814158e1266939643c0e8237f9e3))
+
 ## [5.2.3](https://github.com/scallop-io/sui-scallop-sdk/compare/v5.2.2...v5.2.3) (2026-07-31)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scallop-io/sui-scallop-sdk",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "Typescript sdk for interacting with Scallop contract on SUI",
   "keywords": [
     "sui",

--- a/src/repositories/borrowIncentive/helpers.ts
+++ b/src/repositories/borrowIncentive/helpers.ts
@@ -95,7 +95,6 @@ export const getBorrowIncentivePoolsFromOnChain = async (
   ];
 
   const borrowIncentivePools: BorrowIncentivePools = {};
-
   for (const pool of borrowIncentivePoolsData?.incentive_pools ?? []) {
     const borrowIncentivePoolPoints: OptionalKeys<
       Record<string, BorrowIncentivePoolPoints>
@@ -105,7 +104,7 @@ export const getBorrowIncentivePoolsFromOnChain = async (
       pool
     );
 
-    const poolCoinType = pool.pool_type;
+    const poolCoinType = parsedBorrowIncentivePoolData.poolType;
     const poolCoinName = metadata.parseCoinNameFromType(poolCoinType);
     const poolCoinPrice = coinPrices[poolCoinName] ?? 0;
     const poolCoinDecimal = metadata.getCoinDecimal(poolCoinName);
@@ -160,20 +159,18 @@ export const getBorrowIncentivePoolsFromOnChain = async (
       const isExhausted =
         poolPoint.points <= calculatedPoolPoint.accumulatedPoints;
 
-      if (poolPoint.points > calculatedPoolPoint.accumulatedPoints) {
-        borrowIncentivePoolPoints[coinName] = {
-          symbol,
-          coinName: rewardCoinName,
-          coinType: rewardCoinType,
-          coinDecimal: rewardCoinDecimal,
-          coinPrice: rewardCoinPrice,
-          points: poolPoint.points,
-          distributedPoint: poolPoint.distributedPoint,
-          weightedAmount: poolPoint.weightedAmount,
-          ...calculatedPoolPoint,
-          ...(isExhausted ? { rewardApr: 0 } : {}),
-        };
-      }
+      borrowIncentivePoolPoints[coinName] = {
+        symbol,
+        coinName: rewardCoinName,
+        coinType: rewardCoinType,
+        coinDecimal: rewardCoinDecimal,
+        coinPrice: rewardCoinPrice,
+        points: poolPoint.points,
+        distributedPoint: poolPoint.distributedPoint,
+        weightedAmount: poolPoint.weightedAmount,
+        ...calculatedPoolPoint,
+        ...(isExhausted ? { rewardApr: 0 } : {}),
+      };
     }
 
     const stakedAmount = BigNumber(parsedBorrowIncentivePoolData.staked);

--- a/tests/configSources.spec.ts
+++ b/tests/configSources.spec.ts
@@ -3,13 +3,13 @@ import {
   loadScallopConfigSnapshot,
   type ScallopConfigSources,
 } from 'src/models/scallopConstants/config/index.js';
-import { ADDRESS_INTERFACE, POOL_ADDRESSES, WHITELIST } from './mocks.js';
+import { ADDRESSES, POOL_ADDRESSES, WHITELIST } from './mocks.js';
 
 describe('config sources', () => {
   it('composes a config snapshot from source boundaries', () => {
     const sources: ScallopConfigSources = {
       addressSource: {
-        getAddresses: () => ADDRESS_INTERFACE.mainnet,
+        getAddresses: () => ADDRESSES.mainnet,
       },
       poolAddressSource: {
         getPoolAddresses: () => POOL_ADDRESSES,
@@ -23,9 +23,7 @@ describe('config sources', () => {
       validate: true,
     });
 
-    expect(snapshot.get('core.market')).toBe(
-      ADDRESS_INTERFACE.mainnet.core.market
-    );
+    expect(snapshot.get('core.market')).toBe(ADDRESSES.mainnet.core.market);
     expect(snapshot.poolAddresses.sui).toBeTruthy();
     expect(snapshot.whitelist.lending.has('sui')).toBe(true);
   });

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -1,4 +1,4 @@
-export const ADDRESS_INTERFACE = {
+export const ADDRESSES = {
   mainnet: {
     core: {
       version:
@@ -31,7 +31,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
               feedObject:
-                '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+                '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
             },
           },
         },
@@ -50,7 +50,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef',
               feedObject:
-                '0x24c0247fb22457a719efac7f670cdc79be321b521460bd6bd2ccfa9f80713b14',
+                '0xb14bce71ba7e52cd52947f236604ece40f7a58a1cdf0435c8b94cf6f2d84d302',
             },
           },
         },
@@ -69,7 +69,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '03ae4db29ed4ae33d323568895aa00337e658e348b37509f5372ae51f0af00d5',
               feedObject:
-                '0x7c5b7837c44a69b469325463ac0673ac1aa8435ff44ddb4191c9ae380463647f',
+                '0xb6890901027251f86899e728b1b31dd9821175635a6c9b9b687cd95b8c11103d',
             },
           },
         },
@@ -88,7 +88,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d',
               feedObject:
-                '0x9d0d275efbd37d8a8855f6f2c761fa5983293dd8ce202ee5196626de8fcd4469',
+                '0x24a14523bbc266db0d4f68dab179f416e86848365de2bfe45490af920709e876',
             },
           },
         },
@@ -107,7 +107,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
               feedObject:
-                '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+                '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
             },
           },
         },
@@ -126,7 +126,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
               feedObject:
-                '0x9193fd47f9a0ab99b6e365a464c8a9ae30e6150fc37ed2a89c1586631f6fc4ab',
+                '0x88d7ef5396b1f885ed347f97f3b58daae8a424122668e96bdb4ee847cff62adf',
             },
           },
         },
@@ -145,7 +145,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
               feedObject:
-                '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+                '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
             },
           },
         },
@@ -164,7 +164,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b',
               feedObject:
-                '0x985e3db9f93f76ee8bace7c3dd5cc676a096accd5d9e09e9ae0fb6e492b14572',
+                '0x939e666c48cfac89418f69a24cb857263d4c520f90d94ea0770e295b9857961e',
             },
           },
         },
@@ -184,7 +184,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
               feedObject:
-                '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+                '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
             },
           },
         },
@@ -203,7 +203,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
               feedObject:
-                '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+                '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
             },
           },
         },
@@ -222,7 +222,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
               feedObject:
-                '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+                '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
             },
           },
         },
@@ -241,7 +241,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
               feedObject:
-                '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+                '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
             },
           },
         },
@@ -279,7 +279,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
               feedObject:
-                '0x9193fd47f9a0ab99b6e365a464c8a9ae30e6150fc37ed2a89c1586631f6fc4ab',
+                '0x88d7ef5396b1f885ed347f97f3b58daae8a424122668e96bdb4ee847cff62adf',
             },
           },
         },
@@ -298,7 +298,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979',
               feedObject:
-                '0x5f6583b2b0fe1ecf94aaffeaab8a838794693960cea48c0da282d5f4a24be027',
+                '0xf905acf04bac920b667192ea97ea82e615e6a640167b05dcd090df27d85a3ca2',
             },
           },
         },
@@ -317,7 +317,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '29bdd5248234e33bd93d3b81100b5fa32eaa5997843847e2c2cb16d7c6d9f7ff',
               feedObject:
-                '0x8c7f3a322b94cc69db2a2ac575cbd94bf5766113324c3a3eceac91e3e88a51ed',
+                '0x562957f70afaf8a0870e2959abc3e3f327a8159f803d8c56cff27ac2df260477',
             },
           },
         },
@@ -354,7 +354,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: '2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b',
               feedObject:
-                '0x985e3db9f93f76ee8bace7c3dd5cc676a096accd5d9e09e9ae0fb6e492b14572',
+                '0x939e666c48cfac89418f69a24cb857263d4c520f90d94ea0770e295b9857961e',
             },
           },
         },
@@ -391,7 +391,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
               feedObject:
-                '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+                '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
             },
           },
         },
@@ -408,9 +408,9 @@ export const ADDRESS_INTERFACE = {
             supra: '',
             switchboard: '',
             pyth: {
-              feed: '2ee09cdb656959379b9262f89de5ff3d4dfed0dd34c072b3e22518496a65249c',
+              feed: 'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
               feedObject:
-                '0x72fbf053d6009a40cff74d9708592bd7b86673a0e7b252077e1aa53390976584',
+                '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
             },
           },
         },
@@ -429,7 +429,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'bb5ff26e47a3a6cc7ec2fce1db996c2a145300edc5acaabe43bf9ff7c5dd5d32',
               feedObject:
-                '0xc6352e1ea55d7b5acc3ed690cc3cdf8007978071d7bfd6a189445018cfb366e0',
+                '0xea0d962a2b2cb35bbc262514ea6cfed02fdb3d5bedb193ca0d50bfefc98abebc',
             },
           },
         },
@@ -467,7 +467,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341',
               feedObject:
-                '0xeb7e669f74d976c0b99b6ef9801e3a77716a95f1a15754e0f1399ce3fb60973d',
+                '0xdbea8600eeeb0399df58c28e73b8201ae880a954813131d33bfa6902ccdadd24',
             },
           },
         },
@@ -486,7 +486,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'e67d98cc1fbd94f569d5ba6c3c3c759eb3ffc5d2b28e64538a53ae13efad8fd1',
               feedObject:
-                '0xbc98681c15de1ca1b80a8e26500d43c77f7113368b024de1bf490afcb0387109',
+                '0xcdefc25e55d4faa895874395989407d3b464fe7cf79110155c8f0a770fb9734a',
             },
           },
         },
@@ -505,7 +505,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341',
               feedObject:
-                '0xeb7e669f74d976c0b99b6ef9801e3a77716a95f1a15754e0f1399ce3fb60973d',
+                '0xdbea8600eeeb0399df58c28e73b8201ae880a954813131d33bfa6902ccdadd24',
             },
           },
         },
@@ -524,26 +524,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341',
               feedObject:
-                '0xeb7e669f74d976c0b99b6ef9801e3a77716a95f1a15754e0f1399ce3fb60973d',
-            },
-          },
-        },
-        lofi: {
-          id: '0xf22da9a24ad027cccb5f2d496cbe91de953d363513db08a3a734d361c7c17503',
-          metaData:
-            '0x57a2bf5e6887eca522fe6c3ff0d9d8dc116d072998a477c6c24fe6603107ebb8',
-          treasury: '',
-          coinType:
-            '0xf22da9a24ad027cccb5f2d496cbe91de953d363513db08a3a734d361c7c17503::LOFI::LOFI',
-          symbol: 'LOFI',
-          decimals: 9,
-          oracle: {
-            supra: '',
-            switchboard: '',
-            pyth: {
-              feed: '82eebc2c47490ba9c0f9bc35ea9fb57a7e2bbf69b84a04ea2a3525153b8090ea',
-              feedObject:
-                '0xb65b2888e74b2be973616740da410670ecd6d1d1f4b5456acc7b04ece9c95559',
+                '0xdbea8600eeeb0399df58c28e73b8201ae880a954813131d33bfa6902ccdadd24',
             },
           },
         },
@@ -562,7 +543,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
               feedObject:
-                '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+                '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
             },
           },
         },
@@ -581,7 +562,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
               feedObject:
-                '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+                '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
             },
           },
         },
@@ -599,7 +580,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
               feedObject:
-                '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+                '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
             },
           },
         },
@@ -613,7 +594,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
               feedObject:
-                '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+                '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
             },
           },
           coinType:
@@ -632,7 +613,7 @@ export const ADDRESS_INTERFACE = {
             pyth: {
               feed: 'd7db067954e28f51a96fd50c6d51775094025ced2d60af61ec9803e553471c88',
               feedObject:
-                '0x2731a8e3e9bc69b2d6af6f4c032fcd4856c77e2c21f839134d1ebcc3a16e4b1b',
+                '0xb81afb56abc903ce2c6f7e96fa8fbe3fc66d4ed9dbd9027a7d16d15dca387366',
             },
           },
           coinType:
@@ -640,6 +621,42 @@ export const ADDRESS_INTERFACE = {
           decimals: 9,
           symbol: 'XAUm',
         },
+        scasui: {
+          id: '0xda008a552a2d6a9566fa6204255d55ab32ce00f23e307145dec2644cf83336b2',
+          metaData:
+            '0x71dd901768abcd6e83c4bca76dc7b45fe1ef038c554eba4b1fd76a4c5d91703d',
+          treasury: '',
+          oracle: {
+            supra: '',
+            switchboard: '',
+            pyth: {
+              feed: '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
+              feedObject:
+                '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
+            },
+          },
+          coinType:
+            '0xda008a552a2d6a9566fa6204255d55ab32ce00f23e307145dec2644cf83336b2::sca_sui::SCA_SUI',
+          decimals: 9,
+          symbol: 'scaSUI',
+        },
+        // lofi: {
+        //   id: '0xf22da9a24ad027cccb5f2d496cbe91de953d363513db08a3a734d361c7c17503',
+        //   metaData: '0x57a2bf5e6887eca522fe6c3ff0d9d8dc116d072998a477c6c24fe6603107ebb8',
+        //   treasury: '',
+        //   coinType:
+        //     '0xf22da9a24ad027cccb5f2d496cbe91de953d363513db08a3a734d361c7c17503::LOFI::LOFI',
+        //   symbol: 'LOFI',
+        //   decimals: 9,
+        //   oracle: {
+        //     supra: '',
+        //     switchboard: '',
+        //     pyth: {
+        //       feed: '82eebc2c47490ba9c0f9bc35ea9fb57a7e2bbf69b84a04ea2a3525153b8090ea',
+        //       feedObject: '0xb65b2888e74b2be973616740da410670ecd6d1d1f4b5456acc7b04ece9c95559',
+        //     },
+        //   },
+        // },
       },
       oracles: {
         xOracle:
@@ -667,15 +684,15 @@ export const ADDRESS_INTERFACE = {
         },
         pyth: {
           registry:
-            '0x352c9600e69ff6469f9fc7cd1d0cd5f88264caa5f8908102a223ce663fbb360c',
+            '0xdf5a879c4a572c7a143839c019ca114eaaf696426b6c95a052b865c06f12e279',
           registryCap:
             '0xe4995aaca4e70d4203790fbd22332107131e88b92b81bc976e6fc3a7d5005efd',
           state:
-            '0x1f9310238ee9298fb703c3419030b35b22bb1cc37113e3bb5007c99aec79e5b8',
+            '0x03719fae774ddab3cfcaa53bbc046f0cbe21410019b6280811bf3f9f4b05839d',
           wormhole:
-            '0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a',
+            '0x99de5c967d8206ef4b75c0afab3df2a59eb02b05c282821db803831008ac25b4',
           wormholeState:
-            '0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c',
+            '0xdbca52b9fb4f712e25f61f974586d93ac541bcf8389564f0323bb07215168b5c',
         },
       },
       packages: {
@@ -719,9 +736,9 @@ export const ADDRESS_INTERFACE = {
           upgradeCap: '',
         },
         pyth: {
-          id: '0x1cf913c825c202cbbb71c378edccb9c04723fa07a73b88677b2ef89c6e203a85',
+          id: '0x71fddacc6ecf164bd8f6c081092beeef20945c5da2c74e0b9f3e1d3c7003fadd',
           object:
-            '0x1cf913c825c202cbbb71c378edccb9c04723fa07a73b88677b2ef89c6e203a85',
+            '0x71fddacc6ecf164bd8f6c081092beeef20945c5da2c74e0b9f3e1d3c7003fadd',
           upgradeCap:
             '0xb1f167889643ff766df31745b6e93b92462d8165b0a4f1b095499e15180370f7',
         },
@@ -1126,15 +1143,6 @@ export const ADDRESS_INTERFACE = {
             '0xc751ad85f74617c8174c43538a6de44be8ef4d0115cc74ff38c7e477fa8f6cfb',
           symbol: 'shaWAL',
         },
-        slofi: {
-          coinType:
-            '0x7eb699b346f752cf50a348b015fcaafa00224f88b8c2391a7cba1153ccdb91f9::scallop_lofi::SCALLOP_LOFI',
-          metaData:
-            '0xb55c74ac7302805a8c11a8c1328cae79d04c7484c5efd05b937ab9fd90602277',
-          symbol: 'sLOFI',
-          treasury:
-            '0xd5057447ac659ab3c50fa9cf444ac87a8086f198070b2b47b1e72630d1315c23',
-        },
         sxbtc: {
           coinType:
             '0xa2859d61462635912553746e1b28a54e90b6ad6270f1e7c7db73761a9d6ba1e1::scallop_xbtc::SCALLOP_XBTC',
@@ -1169,7 +1177,7 @@ export const ADDRESS_INTERFACE = {
             '0xba68a930f4f35b589071e1247c44ada1c5e28cb3fac437b2cc6f8d9491c3b4bb',
           metaData:
             '0xbdd57e96225140e42fccf5d357a7f1ebb42d4fe47ceb50cc99f5d02cd72fb5b1',
-          symbol: 'sUSDsui',
+          symbol: 'sUSDSUI',
         },
         sxaum: {
           coinType:
@@ -1180,6 +1188,22 @@ export const ADDRESS_INTERFACE = {
             '0xb8d670c8b7060914466628dab1607ff0f904d25ea91bbfbb1615cdd925e98e5e',
           symbol: 'sXAUm',
         },
+        sscasui: {
+          coinType:
+            '0xa3b4ce56e020cb8086b38fb042b763ccfa1518a43715fb21673a7d814f6e2dac::scallop_sca_sui::SCALLOP_SCA_SUI',
+          treasury:
+            '0x85733627f015ac4f76b198235670f274a44241911623b7c695c784e95afc39bc',
+          metaData:
+            '0xbc36b58fae4e614d5d2614ada71e61e667924351e0ecc4682421a67b5a41ae64',
+          symbol: 'sscaSUI',
+        },
+        // slofi: {
+        //   coinType:
+        //     '0x7eb699b346f752cf50a348b015fcaafa00224f88b8c2391a7cba1153ccdb91f9::scallop_lofi::SCALLOP_LOFI',
+        //   metaData: '0xb55c74ac7302805a8c11a8c1328cae79d04c7484c5efd05b937ab9fd90602277',
+        //   symbol: 'sLOFI',
+        //   treasury: '0xd5057447ac659ab3c50fa9cf444ac87a8086f198070b2b47b1e72630d1315c23',
+        // },
       },
     },
   },
@@ -1225,143 +1249,54 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
     pythFeedObjectId:
-      '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+      '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
     flashloanFeeObject:
       '0x289c770f54b26a4175d57cc6061e3d05f96e52d352cb7c0a51e2e3bacb2aee30',
     isolatedAssetKey: '',
     isIsolated: false,
   },
-  sui: {
-    coinName: 'sui',
-    symbol: 'SUI',
+  cetus: {
+    coinName: 'cetus',
+    symbol: 'CETUS',
     lendingPoolAddress:
-      '0x9c9077abf7a29eebce41e33addbcd6f5246a5221dd733e56ea0f00ae1b25c9e8',
+      '0xc09858f60e74a1b671635bec4e8a2c84a0ff313eb87f525fba3258e88c6b6282',
     collateralPoolAddress:
-      '0x75aacfb7dcbf92ee0111fc1bf975b12569e4ba632e81ed7ae5ac090d40cd3acb',
+      '0xe363967e29b7b9c1245d6d46d63e719de8f90b37e3358c545b55d945ea0b676a',
     borrowDynamic:
-      '0xbf68e6159c99dcaf87717385f1143d2891c2d19663bd51f0bc9b6909e4bb7c27',
+      '0xcc725fd5d71990cdccc7e16c88a2abde6dbcd0bf6e805ccc1c0cb83a106bbf4e',
     interestModel:
-      '0x0dad9baa89b863c15a0487575de7cc428b01f1aa3998ad7a9e9752d96e83ffa9',
+      '0x2f1258aab89d04d11834121599ab1317dfecb582b4246f106df399911125845a',
     riskModel:
-      '0xcd6675864690b5648a6e309f2f02a66914b2b2bd9c31936f4e0f7fc0f792bc86',
+      '0x03fed312dbba624dff5edaf4736891a1c7d864445fd268e7572b42ec7381132e',
     borrowFeeKey:
-      '0xda5ede87a05c0677b17511c859b22d0a2b0229ee374d5d7a1274cb836b9fe5f8',
+      '0xdf5fb0cc4ebbf5eebfae23dfa5b266f6a58c18a894a13054ae60c0eb6e79c382',
     supplyLimitKey:
-      '0x0602418e66fb7a73fa997077bd66f248ad5b090d43344a14b9f1db598ecc1d47',
+      '0xa5ea3d4bf663d7bc667e82b40a98923590ff3851b9ea8e7afbc26c588c7007d3',
     borrowLimitKey:
-      '0x2b33a7efdcf6a6df24f4d8a356dd52f58d75bc023c3f171d99502d4d008b53f0',
-    spool: '0x4f0ba970d3c11db05c8f40c64a15b6a33322db3702d634ced6536960ab6f3ee4',
+      '0xf44218a5f0feb128e6fbe74b91d1e7e9ef859bd23a576ff0de151829e015a157',
+    spool: '0xac1bb13bf4472a637c18c2415fb0e3c1227ea2bcf35242e50563c98215bd298e',
     spoolReward:
-      '0x162250ef72393a4ad3d46294c4e1bdfcb03f04c869d390e7efbfc995353a7ee9',
+      '0x6835c1224126a45086fc6406adc249e3f30df18d779ca4f4e570e38716a17f3f',
     coinMetadataId:
-      '0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3',
+      '0x4c0dce55eff2db5419bbd2d239d1aa22b4a400c01bbb648b058a9883989025da',
     sCoinType:
-      '0xaafc4f740de0dd0dde642a31148fb94517087052f19afb0f7bed1dc41a50c77b::scallop_sui::SCALLOP_SUI',
+      '0xea346ce428f91ab007210443efcea5f5cdbbb3aae7e9affc0ca93f9203c31f0c::scallop_cetus::SCALLOP_CETUS',
     sCoinTreasury:
-      '0x5c1678c8261ac9eec024d4d630006a9f55c80dc0b1aa38a003fcb1d425818c6b',
+      '0xa283c63488773c916cb3d6c64109536160d5eb496caddc721eb39aad2977d735',
     sCoinMetadataId:
-      '0xac724644f481f4870ecdc29b9549aa8ea5180f10827c0d97b493f9f65a91455d',
-    sCoinSymbol: 'sSUI',
-    sCoinName: 'ssui',
+      '0xf022d041455a038d762a091f7a9e9521211f20501bcf8b6913ef5493a023218f',
+    sCoinSymbol: 'sCETUS',
+    sCoinName: 'scetus',
     coinType:
-      '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
-    spoolName: 'ssui',
+      '0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS',
+    spoolName: 'scetus',
     decimals: 9,
     pythFeed:
-      '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
+      'e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef',
     pythFeedObjectId:
-      '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+      '0xb14bce71ba7e52cd52947f236604ece40f7a58a1cdf0435c8b94cf6f2d84d302',
     flashloanFeeObject:
-      '0x27614284a8f0a699ffd35aae8f2572c937ec76771cb21b0d7930ec4491a76ed4',
-    isolatedAssetKey: '',
-    isIsolated: false,
-  },
-  wsol: {
-    coinName: 'wsol',
-    symbol: 'wSOL',
-    lendingPoolAddress:
-      '0x985682c42984cdfb03f9ff7d8923344c2fe096b1ae4b82ea17721af19d22a21f',
-    collateralPoolAddress:
-      '0xdc1cc2c371a043ae8e3c3fe2d013c35f1346960b7dbb4c072982c5b794ed144f',
-    borrowDynamic:
-      '0xe3f301e16d4f1273ea659dd82c5c3f124ca5a5883a5726c7ec0f77bf43b70895',
-    interestModel:
-      '0xd95affaee077006b8dbb4b108c1b087e95fc6e5143ef0682da345d5b35bc6356',
-    riskModel:
-      '0x8e0da6358073144ec3557400c87f04991ba3a13ca7e0d0a19daed45260b32f16',
-    borrowFeeKey:
-      '0x604bffbc817e8e12db15f2373a9e15b2c7adbc510649cdf2cc62a594af90671c',
-    supplyLimitKey:
-      '0xbd419b536b3f9c9d4adfc20372ca6feedc53cc31798ac860dbfc847bcf05f54b',
-    borrowLimitKey:
-      '0x77d453c51948f32564c810bc73f9ba7abde880657b7f89e1c8a3bc28fa36ee87',
-    coinMetadataId:
-      '0x4d2c39082b4477e3e79dc4562d939147ab90c42fc5f3e4acf03b94383cd69b6e',
-    sCoinType:
-      '0x1392650f2eca9e3f6ffae3ff89e42a3590d7102b80e2b430f674730bc30d3259::scallop_wormhole_sol::SCALLOP_WORMHOLE_SOL',
-    sCoinTreasury:
-      '0x760fd66f5be869af4382fa32b812b3c67f0eca1bb1ed7a5578b21d56e1848819',
-    sCoinMetadataId:
-      '0xee202d2013fc09453d695c640088ee08f14afc8f1ae26284b4ebbc4712ff1ba5',
-    sCoinSymbol: 'swSOL',
-    sCoinName: 'swsol',
-    coinType:
-      '0xb7844e289a8410e50fb3ca48d69eb9cf29e27d223ef90353fe1bd8e27ff8f3f8::coin::COIN',
-    decimals: 8,
-    pythFeed:
-      'ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d',
-    pythFeedObjectId:
-      '0x9d0d275efbd37d8a8855f6f2c761fa5983293dd8ce202ee5196626de8fcd4469',
-    flashloanFeeObject:
-      '0xe84bdb35b790fc7bdd1645122ac6ac0fc904531d6772c9e25904fece322c5f34',
-    spool: '',
-    spoolName: 'swsol',
-    spoolReward: '',
-    isolatedAssetKey: '',
-    isIsolated: false,
-  },
-  wusdt: {
-    coinName: 'wusdt',
-    symbol: 'wUSDT',
-    lendingPoolAddress:
-      '0xfbc056f126dd35adc1f8fe985e2cedc8010e687e8e851e1c5b99fdf63cd1c879',
-    collateralPoolAddress:
-      '0x2260cb5b24929dd20a1742f37a61ff3ce4fde5cdb023e2d3ce2e0ce2d90719e3',
-    borrowDynamic:
-      '0xb524030cc8f7cdbf13f1925a0a2b5e77cc52bab73b070f42c5e510f6083da1ba',
-    interestModel:
-      '0x92f93c4431b4c51774d6d964da516af2def18b78f49dbbf519e58449a8ba4659',
-    riskModel:
-      '0xdf89d66988cb506ddeff46f5dfd1d11aaece345e9a05a0c6a18a0788647de2a7',
-    borrowFeeKey:
-      '0xda8f8b3522fc4086eae4ae7ce8844d60aa0dc3eab8ffc91fe93e922a72639b2d',
-    supplyLimitKey:
-      '0xa9cb5ebb90ca6e808a2bd7728cca4a6fa8b565d4deeda96eb23c8322c477c24e',
-    borrowLimitKey:
-      '0xa3278564fc613680a69c10972a0299965bf6e12e9ac171388842fc958de0f90e',
-    spool: '0xcb328f7ffa7f9342ed85af3fdb2f22919e1a06dfb2f713c04c73543870d7548f',
-    spoolReward:
-      '0x2c9f934d67a5baa586ceec2cc24163a2f049a6af3d5ba36b84d8ac40f25c4080',
-    coinMetadataId:
-      '0xfb0e3eb97dd158a5ae979dddfa24348063843c5b20eb8381dd5fa7c93699e45c',
-    sCoinType:
-      '0xe6e5a012ec20a49a3d1d57bd2b67140b96cd4d3400b9d79e541f7bdbab661f95::scallop_wormhole_usdt::SCALLOP_WORMHOLE_USDT',
-    sCoinTreasury:
-      '0x1f02e2fed702b477732d4ad6044aaed04f2e8e586a169153694861a901379df0',
-    sCoinMetadataId:
-      '0x171d0f1ca99d5fefb8b2e40b89899bacdc5417a783906ae119b9cb1c113d59ae',
-    sCoinSymbol: 'swUSDT',
-    sCoinName: 'swusdt',
-    coinType:
-      '0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN',
-    spoolName: 'swusdt',
-    decimals: 6,
-    pythFeed:
-      '2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b',
-    pythFeedObjectId:
-      '0x985e3db9f93f76ee8bace7c3dd5cc676a096accd5d9e09e9ae0fb6e492b14572',
-    flashloanFeeObject:
-      '0x5b61983a19b5159ca348d291e4b595f42db70ccda32852a2ed85528aa65171e4',
+      '0xe65a73d11c31b2d323ad2b9f6b4bb0a3c0df9c1b212eef66c854941186a5ddc7',
     isolatedAssetKey: '',
     isIsolated: false,
   },
@@ -1393,14 +1328,147 @@ export const POOL_ADDRESSES = {
     sCoinName: 'swapt',
     coinType:
       '0x3a5143bb1196e3bcdfab6203d1683ae29edd26294fc8bfeafe4aaa9d2704df37::coin::COIN',
+    spoolName: 'swapt',
     decimals: 8,
     pythFeed:
       '03ae4db29ed4ae33d323568895aa00337e658e348b37509f5372ae51f0af00d5',
     pythFeedObjectId:
-      '0x7c5b7837c44a69b469325463ac0673ac1aa8435ff44ddb4191c9ae380463647f',
+      '0xb6890901027251f86899e728b1b31dd9821175635a6c9b9b687cd95b8c11103d',
     flashloanFeeObject:
       '0x9d5898edcd1e4abcb044273242293a9d036f6a977bf3fe57ab71f5a87c505ee6',
-    spoolName: 'swapt',
+    isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  wsol: {
+    coinName: 'wsol',
+    symbol: 'wSOL',
+    lendingPoolAddress:
+      '0x985682c42984cdfb03f9ff7d8923344c2fe096b1ae4b82ea17721af19d22a21f',
+    collateralPoolAddress:
+      '0xdc1cc2c371a043ae8e3c3fe2d013c35f1346960b7dbb4c072982c5b794ed144f',
+    borrowDynamic:
+      '0xe3f301e16d4f1273ea659dd82c5c3f124ca5a5883a5726c7ec0f77bf43b70895',
+    interestModel:
+      '0xd95affaee077006b8dbb4b108c1b087e95fc6e5143ef0682da345d5b35bc6356',
+    riskModel:
+      '0x8e0da6358073144ec3557400c87f04991ba3a13ca7e0d0a19daed45260b32f16',
+    borrowFeeKey:
+      '0x604bffbc817e8e12db15f2373a9e15b2c7adbc510649cdf2cc62a594af90671c',
+    supplyLimitKey:
+      '0xbd419b536b3f9c9d4adfc20372ca6feedc53cc31798ac860dbfc847bcf05f54b',
+    borrowLimitKey:
+      '0x77d453c51948f32564c810bc73f9ba7abde880657b7f89e1c8a3bc28fa36ee87',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0x4d2c39082b4477e3e79dc4562d939147ab90c42fc5f3e4acf03b94383cd69b6e',
+    sCoinType:
+      '0x1392650f2eca9e3f6ffae3ff89e42a3590d7102b80e2b430f674730bc30d3259::scallop_wormhole_sol::SCALLOP_WORMHOLE_SOL',
+    sCoinTreasury:
+      '0x760fd66f5be869af4382fa32b812b3c67f0eca1bb1ed7a5578b21d56e1848819',
+    sCoinMetadataId:
+      '0xee202d2013fc09453d695c640088ee08f14afc8f1ae26284b4ebbc4712ff1ba5',
+    sCoinSymbol: 'swSOL',
+    sCoinName: 'swsol',
+    coinType:
+      '0xb7844e289a8410e50fb3ca48d69eb9cf29e27d223ef90353fe1bd8e27ff8f3f8::coin::COIN',
+    spoolName: 'swsol',
+    decimals: 8,
+    pythFeed:
+      'ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d',
+    pythFeedObjectId:
+      '0x24a14523bbc266db0d4f68dab179f416e86848365de2bfe45490af920709e876',
+    flashloanFeeObject:
+      '0xe84bdb35b790fc7bdd1645122ac6ac0fc904531d6772c9e25904fece322c5f34',
+    isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  wbtc: {
+    coinName: 'wbtc',
+    symbol: 'wBTC',
+    lendingPoolAddress:
+      '0x65cc08a5aca0a0b8d72e1993ded8d145f06dd102fd0d8f285b92934faed564ab',
+    collateralPoolAddress:
+      '0x1aa4e5cf743cd797b4eb8bf1e614f80ae2cf556ced426cddaaf190ffcd0e59c3',
+    borrowDynamic:
+      '0x6f97dcf54158a5d08f359a213a41e347bc1e6316414288dc1e1b674dc008742e',
+    interestModel:
+      '0x582b915cca0ffca9576a7cedd505d0fd7cb146e9521ccf10e7453ed93705684d',
+    riskModel:
+      '0x1d0a242bf1682e259112239720da19d3155dd99d70b1f4b3b973eecbab858911',
+    borrowFeeKey:
+      '0x654ab7e8ff6d9ef04da697e1f12ca21eaf72ebb495daf877e0776e65187dcb92',
+    supplyLimitKey:
+      '0xac3b0d17df9f98aa2798c54405cf1d8d5356ef22f76f02d150cbe5195e9f3a36',
+    borrowLimitKey:
+      '0x231e13ba6b1eb26c562f4a125778d3152f9a77e31f124bd6012e234a73012169',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0x5d3c6e60eeff8a05b693b481539e7847dfe33013e7070cdcb387f5c0cac05dfd',
+    sCoinType:
+      '0x2cf76a9cf5d3337961d1154283234f94da2dcff18544dfe5cbdef65f319591b5::scallop_wormhole_btc::SCALLOP_WORMHOLE_BTC',
+    sCoinTreasury:
+      '0xe2883934ea42c99bc998bbe0f01dd6d27aa0e27a56455707b1b34e6a41c20baa',
+    sCoinMetadataId:
+      '0x1ba5904dae41699683da767c7a97785a55c51ec1253498c8fe1980169a96523d',
+    sCoinSymbol: 'swBTC',
+    sCoinName: 'swbtc',
+    coinType:
+      '0x027792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881::coin::COIN',
+    spoolName: 'swbtc',
+    decimals: 8,
+    pythFeed:
+      'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
+    pythFeedObjectId:
+      '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
+    flashloanFeeObject:
+      '0x2078490aa37d8fb42b511e5c95e217cb957d141267e16980bc802d76b42719f7',
+    isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  weth: {
+    coinName: 'weth',
+    symbol: 'wETH',
+    lendingPoolAddress:
+      '0xc8fcdff48efc265740ae0b74aae3faccae9ec00034039a113f3339798035108c',
+    collateralPoolAddress:
+      '0xad7ced91ed6e7f2b81805561eee27fa6f3e72fdae561077334c7248583db4dbf',
+    borrowDynamic:
+      '0xd1578e1d1c9c82eb4c5bf14beece8142a67a683b2647d7276e92984119fc1445',
+    interestModel:
+      '0xa1dc08541cd2cb7cfb4e56272292d5c6a4780e80fd210c58abffae98268b5ed9',
+    riskModel:
+      '0x9f05a25fd33a9e8cf33962126b175d038e184f0ee1b87dc41d4cedbe6abebbe5',
+    borrowFeeKey:
+      '0x29672ba8ab4625b8181d8ed739e5344de22a97d417748c4d1276c7379283d7a3',
+    supplyLimitKey:
+      '0x2b957941bdc9432bbc83ab74dc194b6ebb7c927bc4c6926a5492b5503499e509',
+    borrowLimitKey:
+      '0x51f256d87e51a7ca2b1c482923096f4b6dac6beac89d8ecf4c65b7d5764115d6',
+    spool: '0xeec40beccb07c575bebd842eeaabb835f77cd3dab73add433477e57f583a6787',
+    spoolReward:
+      '0x957de68a18d87817de8309b30c1ec269a4d87ae513abbeed86b5619cb9ce1077',
+    coinMetadataId:
+      '0x8900e4ceede3363bef086d6b50ca89d816d0e90bf6bc46efefe1f8455e08f50f',
+    sCoinType:
+      '0x67540ceb850d418679e69f1fb6b2093d6df78a2a699ffc733f7646096d552e9b::scallop_wormhole_eth::SCALLOP_WORMHOLE_ETH',
+    sCoinTreasury:
+      '0x4b7f5da0e306c9d52490a0c1d4091e653d6b89778b9b4f23c877e534e4d9cd21',
+    sCoinMetadataId:
+      '0x077d0fd835b559e5b4bb52641f7627ddbf8b200f9b2cf4e28b3514da2a32a4dd',
+    sCoinSymbol: 'swETH',
+    sCoinName: 'sweth',
+    coinType:
+      '0xaf8cd5edc19c4512f4259f0bee101a40d41ebed738ade5874359610ef8eeced5::coin::COIN',
+    spoolName: 'sweth',
+    decimals: 8,
+    pythFeed:
+      'ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
+    pythFeedObjectId:
+      '0x88d7ef5396b1f885ed347f97f3b58daae8a424122668e96bdb4ee847cff62adf',
+    flashloanFeeObject:
+      '0xd252acb058e77877810c1290564e290a8f9fcab5bc9aca2884ede8a38810cf34',
     isolatedAssetKey: '',
     isIsolated: false,
   },
@@ -1443,188 +1511,99 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
     pythFeedObjectId:
-      '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+      '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
     flashloanFeeObject:
       '0xd241d6a7e44ac11a6689370ed9a98eec389b98b8a6695c61fddede9fa7567b90',
     isolatedAssetKey: '',
     isIsolated: false,
   },
-  deep: {
-    coinName: 'deep',
-    symbol: 'DEEP',
+  wusdt: {
+    coinName: 'wusdt',
+    symbol: 'wUSDT',
     lendingPoolAddress:
-      '0xf4a67ffb43da1e1c61c049f188f19463ea8dbbf2d5ef4722d6df854ff1b1cc03',
+      '0xfbc056f126dd35adc1f8fe985e2cedc8010e687e8e851e1c5b99fdf63cd1c879',
     collateralPoolAddress:
-      '0x3e37fdf8b95de2af87085a264cb4bf50adabad1f6b415243b9cb7aec4a8dab56',
+      '0x2260cb5b24929dd20a1742f37a61ff3ce4fde5cdb023e2d3ce2e0ce2d90719e3',
     borrowDynamic:
-      '0x95e00d7466f97a100e70f08bd37788dc49335796f6f49fab996d40dd0681c6d3',
+      '0xb524030cc8f7cdbf13f1925a0a2b5e77cc52bab73b070f42c5e510f6083da1ba',
     interestModel:
-      '0x4143c298506a332d92ea8a995e6f3991ee3215f58f6fc6441752835d275b9a69',
+      '0x92f93c4431b4c51774d6d964da516af2def18b78f49dbbf519e58449a8ba4659',
+    riskModel:
+      '0xdf89d66988cb506ddeff46f5dfd1d11aaece345e9a05a0c6a18a0788647de2a7',
     borrowFeeKey:
-      '0xb14ee43f4ad2a2c40bac8c4406a401690e93c982e289cf3802fedf74a159cab2',
+      '0xda8f8b3522fc4086eae4ae7ce8844d60aa0dc3eab8ffc91fe93e922a72639b2d',
     supplyLimitKey:
-      '0x599528fdfdc253e90dfd0acf4f4a166b391e2aac1ca6528abbff63225b548fee',
+      '0xa9cb5ebb90ca6e808a2bd7728cca4a6fa8b565d4deeda96eb23c8322c477c24e',
     borrowLimitKey:
-      '0xf4217e8ef9d9c32e8992092e910a77535a8124c19b8a762a673f227f5f765a4e',
+      '0xa3278564fc613680a69c10972a0299965bf6e12e9ac171388842fc958de0f90e',
+    spool: '0xcb328f7ffa7f9342ed85af3fdb2f22919e1a06dfb2f713c04c73543870d7548f',
+    spoolReward:
+      '0x2c9f934d67a5baa586ceec2cc24163a2f049a6af3d5ba36b84d8ac40f25c4080',
     coinMetadataId:
-      '0x6e60b051a08fa836f5a7acd7c464c8d9825bc29c44657fe170fe9b8e1e4770c0',
+      '0xfb0e3eb97dd158a5ae979dddfa24348063843c5b20eb8381dd5fa7c93699e45c',
     sCoinType:
-      '0xeb7a05a3224837c5e5503575aed0be73c091d1ce5e43aa3c3e716e0ae614608f::scallop_deep::SCALLOP_DEEP',
+      '0xe6e5a012ec20a49a3d1d57bd2b67140b96cd4d3400b9d79e541f7bdbab661f95::scallop_wormhole_usdt::SCALLOP_WORMHOLE_USDT',
     sCoinTreasury:
-      '0xc63838fabe37b25ad897392d89876d920f5e0c6a406bf3abcb84753d2829bc88',
+      '0x1f02e2fed702b477732d4ad6044aaed04f2e8e586a169153694861a901379df0',
     sCoinMetadataId:
-      '0x2443014594a500a9119e11c6c6a86e865834f496c4614280ce8cace33c0b072e',
-    sCoinSymbol: 'sDEEP',
-    sCoinName: 'sdeep',
+      '0x171d0f1ca99d5fefb8b2e40b89899bacdc5417a783906ae119b9cb1c113d59ae',
+    sCoinSymbol: 'swUSDT',
+    sCoinName: 'swusdt',
     coinType:
-      '0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP',
+      '0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN',
+    spoolName: 'swusdt',
     decimals: 6,
     pythFeed:
-      '29bdd5248234e33bd93d3b81100b5fa32eaa5997843847e2c2cb16d7c6d9f7ff',
+      '2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b',
     pythFeedObjectId:
-      '0x8c7f3a322b94cc69db2a2ac575cbd94bf5766113324c3a3eceac91e3e88a51ed',
+      '0x939e666c48cfac89418f69a24cb857263d4c520f90d94ea0770e295b9857961e',
     flashloanFeeObject:
-      '0xd54dfb677e9e011e2451375a7a2e318b4f2225c2a0b369bde0afcef8cbb1a863',
-    isolatedAssetKey:
-      '0x208d3a24ba369dcfc8f0387333d1512b98199eb150d2f2a69359ff708cf761e3',
-    spool: '',
-    spoolName: 'sdeep',
-    spoolReward: '',
-    riskModel:
-      '0xf742e6a37bdda54a89ecc89b619ab18a5454ed9cd51728dcbbffe8e3c458024c',
-    isIsolated: false,
-  },
-  weth: {
-    coinName: 'weth',
-    symbol: 'wETH',
-    lendingPoolAddress:
-      '0xc8fcdff48efc265740ae0b74aae3faccae9ec00034039a113f3339798035108c',
-    collateralPoolAddress:
-      '0xad7ced91ed6e7f2b81805561eee27fa6f3e72fdae561077334c7248583db4dbf',
-    borrowDynamic:
-      '0xd1578e1d1c9c82eb4c5bf14beece8142a67a683b2647d7276e92984119fc1445',
-    interestModel:
-      '0xa1dc08541cd2cb7cfb4e56272292d5c6a4780e80fd210c58abffae98268b5ed9',
-    riskModel:
-      '0x9f05a25fd33a9e8cf33962126b175d038e184f0ee1b87dc41d4cedbe6abebbe5',
-    borrowFeeKey:
-      '0x29672ba8ab4625b8181d8ed739e5344de22a97d417748c4d1276c7379283d7a3',
-    supplyLimitKey:
-      '0x2b957941bdc9432bbc83ab74dc194b6ebb7c927bc4c6926a5492b5503499e509',
-    borrowLimitKey:
-      '0x51f256d87e51a7ca2b1c482923096f4b6dac6beac89d8ecf4c65b7d5764115d6',
-    spool: '0xeec40beccb07c575bebd842eeaabb835f77cd3dab73add433477e57f583a6787',
-    spoolReward:
-      '0x957de68a18d87817de8309b30c1ec269a4d87ae513abbeed86b5619cb9ce1077',
-    coinMetadataId:
-      '0x8900e4ceede3363bef086d6b50ca89d816d0e90bf6bc46efefe1f8455e08f50f',
-    sCoinType:
-      '0x67540ceb850d418679e69f1fb6b2093d6df78a2a699ffc733f7646096d552e9b::scallop_wormhole_eth::SCALLOP_WORMHOLE_ETH',
-    sCoinTreasury:
-      '0x4b7f5da0e306c9d52490a0c1d4091e653d6b89778b9b4f23c877e534e4d9cd21',
-    sCoinMetadataId:
-      '0x077d0fd835b559e5b4bb52641f7627ddbf8b200f9b2cf4e28b3514da2a32a4dd',
-    sCoinSymbol: 'swETH',
-    sCoinName: 'sweth',
-    coinType:
-      '0xaf8cd5edc19c4512f4259f0bee101a40d41ebed738ade5874359610ef8eeced5::coin::COIN',
-    spoolName: 'sweth',
-    decimals: 8,
-    pythFeed:
-      'ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
-    pythFeedObjectId:
-      '0x9193fd47f9a0ab99b6e365a464c8a9ae30e6150fc37ed2a89c1586631f6fc4ab',
-    flashloanFeeObject:
-      '0xd252acb058e77877810c1290564e290a8f9fcab5bc9aca2884ede8a38810cf34',
+      '0x5b61983a19b5159ca348d291e4b595f42db70ccda32852a2ed85528aa65171e4',
     isolatedAssetKey: '',
     isIsolated: false,
   },
-  vsui: {
-    coinName: 'vsui',
-    symbol: 'vSUI',
+  sui: {
+    coinName: 'sui',
+    symbol: 'SUI',
     lendingPoolAddress:
-      '0xda9257c0731d8822e8a438ebced13415850d705b779c79958dcf2aeb21fcb43d',
+      '0x9c9077abf7a29eebce41e33addbcd6f5246a5221dd733e56ea0f00ae1b25c9e8',
     collateralPoolAddress:
-      '0x4435e8b8ec2a04094d863aa52deb6ab6f8f47ed8778f4d9f1b27afc4a6e85f1e',
+      '0x75aacfb7dcbf92ee0111fc1bf975b12569e4ba632e81ed7ae5ac090d40cd3acb',
     borrowDynamic:
-      '0x8eae703505246f975e83f5af24780e5f1b89ef403d5a80ea15534624d6f1a503',
+      '0xbf68e6159c99dcaf87717385f1143d2891c2d19663bd51f0bc9b6909e4bb7c27',
     interestModel:
-      '0xaf6a52b5eaaa5af4d9e49d83de0d504c295ae21f3a37560c3f48e0e15a1d4625',
+      '0x0dad9baa89b863c15a0487575de7cc428b01f1aa3998ad7a9e9752d96e83ffa9',
     riskModel:
-      '0x1e862f27a6bd47c3041159a5cf392f549485c6605ed9aa937f16ecc951e82e65',
+      '0xcd6675864690b5648a6e309f2f02a66914b2b2bd9c31936f4e0f7fc0f792bc86',
     borrowFeeKey:
-      '0x5230de0f41a5e4c05b3d1187a90a9eeab491cec97b08b71512d9785e8af36aa6',
+      '0xda5ede87a05c0677b17511c859b22d0a2b0229ee374d5d7a1274cb836b9fe5f8',
     supplyLimitKey:
-      '0x1d40e34d1f365ec431fff020bd75c16b14b340b3ed6c139803cc15c2384621b2',
+      '0x0602418e66fb7a73fa997077bd66f248ad5b090d43344a14b9f1db598ecc1d47',
     borrowLimitKey:
-      '0x4eb206b4417642cfc1b02f80bb5f5e366af2af2f9fb4ea4f4e898ae82367f8a0',
-    spool: '0x69ce8e537e750a95381e6040794afa5ab1758353a1a2e1de7760391b01f91670',
+      '0x2b33a7efdcf6a6df24f4d8a356dd52f58d75bc023c3f171d99502d4d008b53f0',
+    spool: '0x4f0ba970d3c11db05c8f40c64a15b6a33322db3702d634ced6536960ab6f3ee4',
     spoolReward:
-      '0xbca914adce058ad0902c7f3cfcd698392a475f00dcfdc3f76001d0370b98777a',
+      '0x162250ef72393a4ad3d46294c4e1bdfcb03f04c869d390e7efbfc995353a7ee9',
     coinMetadataId:
-      '0xabd84a23467b33854ab25cf862006fd97479f8f6f53e50fe732c43a274d939bd',
+      '0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3',
     sCoinType:
-      '0xe1a1cc6bcf0001a015eab84bcc6713393ce20535f55b8b6f35c142e057a25fbe::scallop_v_sui::SCALLOP_V_SUI',
+      '0xaafc4f740de0dd0dde642a31148fb94517087052f19afb0f7bed1dc41a50c77b::scallop_sui::SCALLOP_SUI',
     sCoinTreasury:
-      '0xc06688ee1af25abc286ffb1d18ce273d1d5907cd1064c25f4e8ca61ea989c1d1',
+      '0x5c1678c8261ac9eec024d4d630006a9f55c80dc0b1aa38a003fcb1d425818c6b',
     sCoinMetadataId:
-      '0xa96cc21ddfb6486be4a96cda0c58734e4ddea2a8c04984f9e6121d8fae997ddf',
-    sCoinSymbol: 'svSUI',
-    sCoinName: 'svsui',
+      '0xac724644f481f4870ecdc29b9549aa8ea5180f10827c0d97b493f9f65a91455d',
+    sCoinSymbol: 'sSUI',
+    sCoinName: 'ssui',
     coinType:
-      '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
-    spoolName: 'svsui',
+      '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+    spoolName: 'ssui',
     decimals: 9,
     pythFeed:
       '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
     pythFeedObjectId:
-      '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+      '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
     flashloanFeeObject:
-      '0x0069cddee7a5c0b1d34beb5ef0620f978096525f1830b055f38b110f40d73fbb',
-    isolatedAssetKey: '',
-    isIsolated: false,
-  },
-  wbtc: {
-    coinName: 'wbtc',
-    symbol: 'wBTC',
-    lendingPoolAddress:
-      '0x65cc08a5aca0a0b8d72e1993ded8d145f06dd102fd0d8f285b92934faed564ab',
-    collateralPoolAddress:
-      '0x1aa4e5cf743cd797b4eb8bf1e614f80ae2cf556ced426cddaaf190ffcd0e59c3',
-    borrowDynamic:
-      '0x6f97dcf54158a5d08f359a213a41e347bc1e6316414288dc1e1b674dc008742e',
-    interestModel:
-      '0x582b915cca0ffca9576a7cedd505d0fd7cb146e9521ccf10e7453ed93705684d',
-    riskModel:
-      '0x1d0a242bf1682e259112239720da19d3155dd99d70b1f4b3b973eecbab858911',
-    borrowFeeKey:
-      '0x654ab7e8ff6d9ef04da697e1f12ca21eaf72ebb495daf877e0776e65187dcb92',
-    supplyLimitKey:
-      '0xac3b0d17df9f98aa2798c54405cf1d8d5356ef22f76f02d150cbe5195e9f3a36',
-    borrowLimitKey:
-      '0x231e13ba6b1eb26c562f4a125778d3152f9a77e31f124bd6012e234a73012169',
-    coinMetadataId:
-      '0x5d3c6e60eeff8a05b693b481539e7847dfe33013e7070cdcb387f5c0cac05dfd',
-    sCoinType:
-      '0x2cf76a9cf5d3337961d1154283234f94da2dcff18544dfe5cbdef65f319591b5::scallop_wormhole_btc::SCALLOP_WORMHOLE_BTC',
-    sCoinTreasury:
-      '0xe2883934ea42c99bc998bbe0f01dd6d27aa0e27a56455707b1b34e6a41c20baa',
-    sCoinMetadataId:
-      '0x1ba5904dae41699683da767c7a97785a55c51ec1253498c8fe1980169a96523d',
-    sCoinSymbol: 'swBTC',
-    sCoinName: 'swbtc',
-    coinType:
-      '0x027792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881::coin::COIN',
-    decimals: 8,
-    pythFeed:
-      'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
-    pythFeedObjectId:
-      '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
-    flashloanFeeObject:
-      '0x2078490aa37d8fb42b511e5c95e217cb957d141267e16980bc802d76b42719f7',
-    spool: '',
-    spoolName: 'swbtc',
-    spoolReward: '',
+      '0x27614284a8f0a699ffd35aae8f2572c937ec76771cb21b0d7930ec4491a76ed4',
     isolatedAssetKey: '',
     isIsolated: false,
   },
@@ -1667,7 +1646,7 @@ export const POOL_ADDRESSES = {
     pythFeed:
       '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
     pythFeedObjectId:
-      '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+      '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
     flashloanFeeObject:
       '0xac87fde83d434554ec300c1334c9a622aa5b59e82a04334dc99e1cc1f75d4eae',
     isolatedAssetKey: '',
@@ -1712,98 +1691,98 @@ export const POOL_ADDRESSES = {
     pythFeed:
       '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
     pythFeedObjectId:
-      '0x801dbc2f0053d34734814b2d6df491ce7807a725fe9a01ad74a07e9c51396c37',
+      '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
     flashloanFeeObject:
       '0xb9f505d532de1d6c9f3a8522a2d16f2958b75c0ed939d4f80b96f584a2a8ed5e',
     isolatedAssetKey: '',
     isIsolated: false,
   },
-  sbusdt: {
-    coinName: 'sbusdt',
-    symbol: 'sbUSDT',
+  vsui: {
+    coinName: 'vsui',
+    symbol: 'vSUI',
     lendingPoolAddress:
-      '0x958ca02058a7dd8b00e26ed6988f45d7c2834ae2a47ee4c4a8fdedea155f18ca',
+      '0xda9257c0731d8822e8a438ebced13415850d705b779c79958dcf2aeb21fcb43d',
     collateralPoolAddress:
-      '0x63c861f97192ceab2dabb1e74649ae87a9e36c33aaedcc43e40a811d3a39e653',
+      '0x4435e8b8ec2a04094d863aa52deb6ab6f8f47ed8778f4d9f1b27afc4a6e85f1e',
     borrowDynamic:
-      '0xf1ef9a19881ed6ddeb88f361c83f37c592ec5b9c64fe715383f63ccc094be205',
+      '0x8eae703505246f975e83f5af24780e5f1b89ef403d5a80ea15534624d6f1a503',
     interestModel:
-      '0x62c46e4667c4fa69a29030ecbc0f661c61365d02adc3810b08b11cfd8f42ca1c',
+      '0xaf6a52b5eaaa5af4d9e49d83de0d504c295ae21f3a37560c3f48e0e15a1d4625',
     riskModel:
-      '0x59d5f3dbcd14a0aab6ee6e2879803e10b0a752119d19c4ac0bd389d71dc8c2bf',
+      '0x1e862f27a6bd47c3041159a5cf392f549485c6605ed9aa937f16ecc951e82e65',
     borrowFeeKey:
-      '0xa418990ad042e97cca61830476483933b9e026970fc33451072b2627ccb31da2',
+      '0x5230de0f41a5e4c05b3d1187a90a9eeab491cec97b08b71512d9785e8af36aa6',
     supplyLimitKey:
-      '0x93641bfb62ea40760f0c15911b4ec0eb866f8725e36b0ca9a786775d93629139',
+      '0x1d40e34d1f365ec431fff020bd75c16b14b340b3ed6c139803cc15c2384621b2',
     borrowLimitKey:
-      '0x953a9b8d5353abb38db21a2cbbc5c54f8f23348895acb26cbe2c0ab61b54635d',
+      '0x4eb206b4417642cfc1b02f80bb5f5e366af2af2f9fb4ea4f4e898ae82367f8a0',
+    spool: '0x69ce8e537e750a95381e6040794afa5ab1758353a1a2e1de7760391b01f91670',
+    spoolReward:
+      '0xbca914adce058ad0902c7f3cfcd698392a475f00dcfdc3f76001d0370b98777a',
     coinMetadataId:
-      '0xda61b33ac61ed4c084bbda65a2229459ed4eb2185729e70498538f0688bec3cc',
+      '0xabd84a23467b33854ab25cf862006fd97479f8f6f53e50fe732c43a274d939bd',
     sCoinType:
-      '0xb1d7df34829d1513b73ba17cb7ad90c88d1e104bb65ab8f62f13e0cc103783d3::scallop_sb_usdt::SCALLOP_SB_USDT',
+      '0xe1a1cc6bcf0001a015eab84bcc6713393ce20535f55b8b6f35c142e057a25fbe::scallop_v_sui::SCALLOP_V_SUI',
     sCoinTreasury:
-      '0x58bdf6a9752e3a60144d0b70e8608d630dfd971513e2b2bfa7282f5eaa7d04d8',
+      '0xc06688ee1af25abc286ffb1d18ce273d1d5907cd1064c25f4e8ca61ea989c1d1',
     sCoinMetadataId:
-      '0x1ce77b036043c8fdcc5cd050ed06433ae60296b194c2abf7ade8b7b7c8386d36',
-    sCoinSymbol: 'ssbUSDT',
-    sCoinName: 'ssbusdt',
+      '0xa96cc21ddfb6486be4a96cda0c58734e4ddea2a8c04984f9e6121d8fae997ddf',
+    sCoinSymbol: 'svSUI',
+    sCoinName: 'svsui',
     coinType:
-      '0x375f70cf2ae4c00bf37117d0c85a2c71545e6ee05c4a5c7d282cd66a4504b068::usdt::USDT',
-    decimals: 6,
+      '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT',
+    spoolName: 'svsui',
+    decimals: 9,
     pythFeed:
-      '2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b',
+      '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
     pythFeedObjectId:
-      '0x985e3db9f93f76ee8bace7c3dd5cc676a096accd5d9e09e9ae0fb6e492b14572',
+      '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
     flashloanFeeObject:
-      '0x8216d9d04e53af658676cb9a2834140a51a915551fe8a34a27e6885792bdd518',
-    spool: '',
-    spoolName: 'ssbusdt',
-    spoolReward: '',
+      '0x0069cddee7a5c0b1d34beb5ef0620f978096525f1830b055f38b110f40d73fbb',
     isolatedAssetKey: '',
     isIsolated: false,
   },
-  cetus: {
-    coinName: 'cetus',
-    symbol: 'CETUS',
+  sca: {
+    coinName: 'sca',
+    symbol: 'SCA',
     lendingPoolAddress:
-      '0xc09858f60e74a1b671635bec4e8a2c84a0ff313eb87f525fba3258e88c6b6282',
+      '0x6fc7d4211fc7018b6c75e7b908b88f2e0536443239804a3d32af547637bd28d7',
     collateralPoolAddress:
-      '0xe363967e29b7b9c1245d6d46d63e719de8f90b37e3358c545b55d945ea0b676a',
+      '0xff677a5d9e9dc8f08f0a8681ebfc7481d1c7d57bc441f2881974adcdd7b13c31',
     borrowDynamic:
-      '0xcc725fd5d71990cdccc7e16c88a2abde6dbcd0bf6e805ccc1c0cb83a106bbf4e',
+      '0x4e24f52edd739dab59ca4c6353ca430b7ce57e7f333abd0957958570a7cd09ca',
     interestModel:
-      '0x2f1258aab89d04d11834121599ab1317dfecb582b4246f106df399911125845a',
+      '0xbdcd48cf5b1a814911dc2d5c72d393a980c87820199fe5d799289ce94f4c47df',
     riskModel:
-      '0x03fed312dbba624dff5edaf4736891a1c7d864445fd268e7572b42ec7381132e',
+      '0xc437c24b67b8e2676907700fa395af337ad6463d2c0b4f4fa2e9276414026089',
     borrowFeeKey:
-      '0xdf5fb0cc4ebbf5eebfae23dfa5b266f6a58c18a894a13054ae60c0eb6e79c382',
+      '0xee55ba0f9800a62d9e7aef667f87e658258f41814d2c9fa02e25590671b4e5ad',
     supplyLimitKey:
-      '0xa5ea3d4bf663d7bc667e82b40a98923590ff3851b9ea8e7afbc26c588c7007d3',
+      '0x8dd938856b972a10ea27ecab2af7ed78e48fc5f6ccedaf2b2119959f747dc2e3',
     borrowLimitKey:
-      '0xf44218a5f0feb128e6fbe74b91d1e7e9ef859bd23a576ff0de151829e015a157',
-    spool: '0xac1bb13bf4472a637c18c2415fb0e3c1227ea2bcf35242e50563c98215bd298e',
-    spoolReward:
-      '0x6835c1224126a45086fc6406adc249e3f30df18d779ca4f4e570e38716a17f3f',
+      '0x04c7de61c5b42972f9bf6a8b1848e5fea2d037ee8deba81741ecd4a70aa80d30',
+    spool: '',
+    spoolReward: '',
     coinMetadataId:
-      '0x4c0dce55eff2db5419bbd2d239d1aa22b4a400c01bbb648b058a9883989025da',
+      '0x5d26a1e9a55c88147ac870bfa31b729d7f49f8804b8b3adfdf3582d301cca844',
     sCoinType:
-      '0xea346ce428f91ab007210443efcea5f5cdbbb3aae7e9affc0ca93f9203c31f0c::scallop_cetus::SCALLOP_CETUS',
+      '0x5ca17430c1d046fae9edeaa8fd76c7b4193a00d764a0ecfa9418d733ad27bc1e::scallop_sca::SCALLOP_SCA',
     sCoinTreasury:
-      '0xa283c63488773c916cb3d6c64109536160d5eb496caddc721eb39aad2977d735',
+      '0xe04bfc95e00252bd654ee13c08edef9ac5e4b6ae4074e8390db39e9a0109c529',
     sCoinMetadataId:
-      '0xf022d041455a038d762a091f7a9e9521211f20501bcf8b6913ef5493a023218f',
-    sCoinSymbol: 'sCETUS',
-    sCoinName: 'scetus',
+      '0x27e3877491b308dfac46fb3d9f7dfa6a1e8b7dc3c374e92ecda7976055746964',
+    sCoinSymbol: 'sSCA',
+    sCoinName: 'ssca',
     coinType:
-      '0x06864a6f921804860930db6ddbe2e16acdf8504495ea7481637a1c8b9a8fe54b::cetus::CETUS',
-    spoolName: 'scetus',
+      '0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA',
+    spoolName: 'ssca',
     decimals: 9,
     pythFeed:
-      'e5b274b2611143df055d6e7cd8d93fe1961716bcd4dca1cad87a83bc1e78c1ef',
+      '7e17f0ac105abe9214deb9944c30264f5986bf292869c6bd8e8da3ccd92d79bc',
     pythFeedObjectId:
-      '0x24c0247fb22457a719efac7f670cdc79be321b521460bd6bd2ccfa9f80713b14',
+      '0xf6de1d3279a269a597d813cbaca59aa906543ab9a8c64e84a4722f1a20863985',
     flashloanFeeObject:
-      '0xe65a73d11c31b2d323ad2b9f6b4bb0a3c0df9c1b212eef66c854941186a5ddc7',
+      '0xe04e46471754b6f48d81c549ecfec09de02733715a63bec02364c6ac7c4dd2dc',
     isolatedAssetKey: '',
     isIsolated: false,
   },
@@ -1826,6 +1805,8 @@ export const POOL_ADDRESSES = {
       '0x812fe508b78d3e0817149c0b39976221ddb267b5cc9514e81679f9b9a2f3624c',
     borrowLimitKey:
       '0x165c274c67eda2b0d13563124741fffd0ce7d643f4c1c4b59d7e53a83796ae25',
+    spool: '',
+    spoolReward: '',
     coinMetadataId:
       '0x89b04ba87f8832d4d76e17a1c9dce72eb3e64d372cf02012b8d2de5384faeef0',
     sCoinType:
@@ -1838,17 +1819,228 @@ export const POOL_ADDRESSES = {
     sCoinName: 'ssbeth',
     coinType:
       '0xd0e89b2af5e4910726fbcd8b8dd37bb79b29e5f83f7491bca830e94f7f226d29::eth::ETH',
+    spoolName: 'ssbeth',
     decimals: 8,
     pythFeed:
       'ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
     pythFeedObjectId:
-      '0x9193fd47f9a0ab99b6e365a464c8a9ae30e6150fc37ed2a89c1586631f6fc4ab',
+      '0x88d7ef5396b1f885ed347f97f3b58daae8a424122668e96bdb4ee847cff62adf',
     flashloanFeeObject:
       '0x8f2a845b337d08cf4fbd7c7c5d3d23f2c94ed2a85c0d4dd7ef0a26fc8d3b9df6',
-    spool: '',
-    spoolName: 'ssbeth',
-    spoolReward: '',
     isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  fdusd: {
+    coinName: 'fdusd',
+    symbol: 'FDUSD',
+    lendingPoolAddress:
+      '0x4f46051a01f05c3ad9aecf29a771aad5c884e1a1888e08d7709085e3a095bc9c',
+    collateralPoolAddress:
+      '0x4f6647a9afcfdb62bb9b27e4d1cb7bd7130aca1b4f13fa7164453c869c1681ae',
+    borrowDynamic:
+      '0x4ddcf19b6290a8b048ecb314b14ef7f52c1c5b9ddc9259a2a242cd91d681a085',
+    interestModel:
+      '0xb57a33706b29d2d253c74c1c0869e6e20da99036338d2b0b7235ab41621ee9dd',
+    riskModel:
+      '0xd65fb21758dc1e6184940a1a27efb13228d7cf5e19f6dcca06cc2d996af4a6b9',
+    borrowFeeKey:
+      '0xafe673a27747b063fa918d2dfe47794e44af553737ac562c2a63186539a07f45',
+    supplyLimitKey:
+      '0x730e0785ba056a7a95f4a6959371a598d7fe782e81c40785c79982ced4cf4e35',
+    borrowLimitKey:
+      '0x1630c6954918a06fe56312afb8958366c5ed7af653dae0e32c09d088da38577e',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0xdebee5265a67c186ed87fe93303d33dfe1de53e3b4fd7d9329c2852860acd3e7',
+    sCoinType:
+      '0x6711551c1e7652a270d9fbf0eee25d99594c157cde3cb5fbb49035eb59b1b001::scallop_fdusd::SCALLOP_FDUSD',
+    sCoinTreasury:
+      '0xdad9bc6293e694f67a5274ea51b596e0bdabfafc585ae6d7e82888e65f1a03e0',
+    sCoinMetadataId:
+      '0xb1529a3b5e5831d19a722493eec19785f613945d3dc984602d44a418f990d73f',
+    sCoinSymbol: 'sFDUSD',
+    sCoinName: 'sfdusd',
+    coinType:
+      '0xf16e6b723f242ec745dfd7634ad072c42d5c1d9ac9d62a39c381303eaa57693a::fdusd::FDUSD',
+    spoolName: 'sfdusd',
+    decimals: 6,
+    pythFeed:
+      'ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979',
+    pythFeedObjectId:
+      '0xf905acf04bac920b667192ea97ea82e615e6a640167b05dcd090df27d85a3ca2',
+    flashloanFeeObject:
+      '0x5e32556f5bb64358ddc9a2e9e1ec3b3053cdcbd6351e9d422058f6b9794755e1',
+    isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  deep: {
+    coinName: 'deep',
+    symbol: 'DEEP',
+    lendingPoolAddress:
+      '0xf4a67ffb43da1e1c61c049f188f19463ea8dbbf2d5ef4722d6df854ff1b1cc03',
+    collateralPoolAddress:
+      '0x3e37fdf8b95de2af87085a264cb4bf50adabad1f6b415243b9cb7aec4a8dab56',
+    borrowDynamic:
+      '0x95e00d7466f97a100e70f08bd37788dc49335796f6f49fab996d40dd0681c6d3',
+    interestModel:
+      '0x4143c298506a332d92ea8a995e6f3991ee3215f58f6fc6441752835d275b9a69',
+    riskModel:
+      '0xf742e6a37bdda54a89ecc89b619ab18a5454ed9cd51728dcbbffe8e3c458024c',
+    borrowFeeKey:
+      '0xb14ee43f4ad2a2c40bac8c4406a401690e93c982e289cf3802fedf74a159cab2',
+    supplyLimitKey:
+      '0x599528fdfdc253e90dfd0acf4f4a166b391e2aac1ca6528abbff63225b548fee',
+    borrowLimitKey:
+      '0xf4217e8ef9d9c32e8992092e910a77535a8124c19b8a762a673f227f5f765a4e',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0x6e60b051a08fa836f5a7acd7c464c8d9825bc29c44657fe170fe9b8e1e4770c0',
+    sCoinType:
+      '0xeb7a05a3224837c5e5503575aed0be73c091d1ce5e43aa3c3e716e0ae614608f::scallop_deep::SCALLOP_DEEP',
+    sCoinTreasury:
+      '0xc63838fabe37b25ad897392d89876d920f5e0c6a406bf3abcb84753d2829bc88',
+    sCoinMetadataId:
+      '0x2443014594a500a9119e11c6c6a86e865834f496c4614280ce8cace33c0b072e',
+    sCoinSymbol: 'sDEEP',
+    sCoinName: 'sdeep',
+    coinType:
+      '0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP',
+    spoolName: 'sdeep',
+    decimals: 6,
+    pythFeed:
+      '29bdd5248234e33bd93d3b81100b5fa32eaa5997843847e2c2cb16d7c6d9f7ff',
+    pythFeedObjectId:
+      '0x562957f70afaf8a0870e2959abc3e3f327a8159f803d8c56cff27ac2df260477',
+    flashloanFeeObject:
+      '0xd54dfb677e9e011e2451375a7a2e318b4f2225c2a0b369bde0afcef8cbb1a863',
+    isolatedAssetKey:
+      '0x208d3a24ba369dcfc8f0387333d1512b98199eb150d2f2a69359ff708cf761e3',
+    isIsolated: false,
+  },
+  fud: {
+    coinName: 'fud',
+    symbol: 'FUD',
+    lendingPoolAddress:
+      '0xefed2cbe76b344792ac724523c8b2236740d1cea2100d46a0ed0dc760c7f4231',
+    collateralPoolAddress: '',
+    borrowDynamic:
+      '0x14367ddca30e2860cb89ed4eaca20c7ece260c5d59dd9990d2c85a8321326acb',
+    interestModel:
+      '0x2600ac100ef154eb2329ffd3aad47aca308ff9f9348de3e8e94aaeb906ec2303',
+    borrowFeeKey:
+      '0xa87e8b26e07ff35ac9fb57adcc779be2883080fc7d12de2d9e7e16d8d8d5e529',
+    supplyLimitKey:
+      '0xf98419aecc37a3c5de716f8ec590f8991a5be34da72ce1a2da09531ff45adf7d',
+    borrowLimitKey:
+      '0x3d928a001c453c50004baa54e14b0a0e1b0907d9c613dfd76064fd7ed4e8beb8',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0x01087411ef48aaac1eb6e24803213e3a60a03b147dac930e5e341f17a85e524e',
+    sCoinType:
+      '0xe56d5167f427cbe597da9e8150ef5c337839aaf46891d62468dcf80bdd8e10d1::scallop_fud::SCALLOP_FUD',
+    sCoinTreasury:
+      '0xf25212f11d182decff7a86165699a73e3d5787aced203ca539f43cfbc10db867',
+    sCoinMetadataId:
+      '0x4e03390de36b8c84e0a8297d3d0d08a8a34bed93787e37fcb26bfc26df33226c',
+    sCoinSymbol: 'sFUD',
+    sCoinName: 'sfud',
+    coinType:
+      '0x76cb819b01abed502bee8a702b4c2d547532c12f25001c9dea795a5e631c26f1::fud::FUD',
+    spoolName: 'sfud',
+    decimals: 5,
+    pythFeed: '',
+    pythFeedObjectId: '',
+    flashloanFeeObject:
+      '0x1ddda368a5f37d7b8c53879cb333ccfd520fc4a3e2fc98b9b5fdacd1a5945d5a',
+    isolatedAssetKey:
+      '0xfcb533e9e4e31f9c9f32d6cbf7fbb3425f1d60474e229a363a2dc7f835d587e2',
+    isIsolated: true,
+  },
+  sbusdt: {
+    coinName: 'sbusdt',
+    symbol: 'sbUSDT',
+    lendingPoolAddress:
+      '0x958ca02058a7dd8b00e26ed6988f45d7c2834ae2a47ee4c4a8fdedea155f18ca',
+    collateralPoolAddress:
+      '0x63c861f97192ceab2dabb1e74649ae87a9e36c33aaedcc43e40a811d3a39e653',
+    borrowDynamic:
+      '0xf1ef9a19881ed6ddeb88f361c83f37c592ec5b9c64fe715383f63ccc094be205',
+    interestModel:
+      '0x62c46e4667c4fa69a29030ecbc0f661c61365d02adc3810b08b11cfd8f42ca1c',
+    riskModel:
+      '0x59d5f3dbcd14a0aab6ee6e2879803e10b0a752119d19c4ac0bd389d71dc8c2bf',
+    borrowFeeKey:
+      '0xa418990ad042e97cca61830476483933b9e026970fc33451072b2627ccb31da2',
+    supplyLimitKey:
+      '0x93641bfb62ea40760f0c15911b4ec0eb866f8725e36b0ca9a786775d93629139',
+    borrowLimitKey:
+      '0x953a9b8d5353abb38db21a2cbbc5c54f8f23348895acb26cbe2c0ab61b54635d',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0xda61b33ac61ed4c084bbda65a2229459ed4eb2185729e70498538f0688bec3cc',
+    sCoinType:
+      '0xb1d7df34829d1513b73ba17cb7ad90c88d1e104bb65ab8f62f13e0cc103783d3::scallop_sb_usdt::SCALLOP_SB_USDT',
+    sCoinTreasury:
+      '0x58bdf6a9752e3a60144d0b70e8608d630dfd971513e2b2bfa7282f5eaa7d04d8',
+    sCoinMetadataId:
+      '0x1ce77b036043c8fdcc5cd050ed06433ae60296b194c2abf7ade8b7b7c8386d36',
+    sCoinSymbol: 'ssbUSDT',
+    sCoinName: 'ssbusdt',
+    coinType:
+      '0x375f70cf2ae4c00bf37117d0c85a2c71545e6ee05c4a5c7d282cd66a4504b068::usdt::USDT',
+    spoolName: 'ssbusdt',
+    decimals: 6,
+    pythFeed:
+      '2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b',
+    pythFeedObjectId:
+      '0x939e666c48cfac89418f69a24cb857263d4c520f90d94ea0770e295b9857961e',
+    flashloanFeeObject:
+      '0x8216d9d04e53af658676cb9a2834140a51a915551fe8a34a27e6885792bdd518',
+    isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  blub: {
+    coinName: 'blub',
+    symbol: 'BLUB',
+    lendingPoolAddress:
+      '0x4dede1d8eda98647c3fc9838e94a890b73ca37a20764087eb78ba0473edea1a5',
+    collateralPoolAddress: '',
+    borrowDynamic:
+      '0xb2e9df6917ff3cb93fc4361102504c2d225913b3860458ef40f83b370601bec2',
+    interestModel:
+      '0xec07bfcf93df52d1c0dabecc88b1ee66445a2fda6b98378c19d8e029022f2012',
+    borrowFeeKey:
+      '0x59b820845932c1f151793b1c6e605ad993535784ccfaa83e709207d6aed3ab99',
+    supplyLimitKey:
+      '0xc25e930484a10498a53562cfb87da47280e842564d455f25e5b80a913002d5a0',
+    borrowLimitKey:
+      '0xaf4560140b2c6906befd546cc556f7c459964e7c31e20a6e1ab992bbc6d12b7f',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0xac32b519790cae96c3317457d903d61d04f1bc8f7710096d80fcba72c7a53703',
+    sCoinType:
+      '0xe72f65446eabfad2103037af2d49d24599106fb44bf4c046c1e7e9acf6844dd0::scallop_blub::SCALLOP_BLUB',
+    sCoinTreasury:
+      '0x87d34361dfd0e2accc946684d10b176484f348892f6cc51a829418040c4700e1',
+    sCoinMetadataId:
+      '0xfa11263cb39de80b9e224d7e0391866a7e779d3d62451de82a91ba601bfb1ce3',
+    sCoinSymbol: 'sBLUB',
+    sCoinName: 'sblub',
+    coinType:
+      '0xfa7ac3951fdca92c5200d468d31a365eb03b2be9936fde615e69f0c1274ad3a0::BLUB::BLUB',
+    spoolName: 'sblub',
+    decimals: 2,
+    pythFeed: '',
+    pythFeedObjectId: '',
+    flashloanFeeObject:
+      '0x813176c9af63d6128e41f58ac9c02b9785c3a070a01466d1cb79de3c4691a605',
+    isolatedAssetKey:
+      '0x30a8f1dbf9dc05dae26c25fac6dfa80fa2d886e05e61cefc697b94959dd75007',
     isIsolated: false,
   },
   sbwbtc: {
@@ -1870,6 +2062,8 @@ export const POOL_ADDRESSES = {
       '0x4f5dfd04f32cc7ba8fba665486838fd3a291324980460d31bf79918a6b68a112',
     borrowLimitKey:
       '0xc32b0a82ae08248912c39da03c1b347bcfbc7b63da0385e24306c4b97777da56',
+    spool: '',
+    spoolReward: '',
     coinMetadataId:
       '0x53e1cae1ad70a778d0b450d36c7c2553314ca029919005aad26945d65a8fb784',
     sCoinType:
@@ -1882,60 +2076,16 @@ export const POOL_ADDRESSES = {
     sCoinName: 'ssbwbtc',
     coinType:
       '0xaafb102dd0902f5055cadecd687fb5b71ca82ef0e0285d90afde828ec58ca96b::btc::BTC',
+    spoolName: 'ssbwbtc',
     decimals: 8,
     pythFeed:
       'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
     pythFeedObjectId:
-      '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+      '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
     flashloanFeeObject:
       '0x4cb4c290fa0e4940d01356be33b9df660f650ddbffd658807316c3d9cb9ce848',
-    spool: '',
-    spoolName: 'ssbwbtc',
-    spoolReward: '',
     isolatedAssetKey: '',
     isIsolated: false,
-  },
-  fud: {
-    coinName: 'fud',
-    symbol: 'FUD',
-    lendingPoolAddress:
-      '0xefed2cbe76b344792ac724523c8b2236740d1cea2100d46a0ed0dc760c7f4231',
-    collateralPoolAddress: '',
-    borrowDynamic:
-      '0x14367ddca30e2860cb89ed4eaca20c7ece260c5d59dd9990d2c85a8321326acb',
-    interestModel:
-      '0x2600ac100ef154eb2329ffd3aad47aca308ff9f9348de3e8e94aaeb906ec2303',
-    borrowFeeKey:
-      '0xa87e8b26e07ff35ac9fb57adcc779be2883080fc7d12de2d9e7e16d8d8d5e529',
-    supplyLimitKey:
-      '0xf98419aecc37a3c5de716f8ec590f8991a5be34da72ce1a2da09531ff45adf7d',
-    borrowLimitKey:
-      '0x3d928a001c453c50004baa54e14b0a0e1b0907d9c613dfd76064fd7ed4e8beb8',
-    coinMetadataId:
-      '0x01087411ef48aaac1eb6e24803213e3a60a03b147dac930e5e341f17a85e524e',
-    sCoinType:
-      '0xe56d5167f427cbe597da9e8150ef5c337839aaf46891d62468dcf80bdd8e10d1::scallop_fud::SCALLOP_FUD',
-    sCoinTreasury:
-      '0xf25212f11d182decff7a86165699a73e3d5787aced203ca539f43cfbc10db867',
-    sCoinMetadataId:
-      '0x4e03390de36b8c84e0a8297d3d0d08a8a34bed93787e37fcb26bfc26df33226c',
-    sCoinSymbol: 'sFUD',
-    sCoinName: 'sfud',
-    coinType:
-      '0x76cb819b01abed502bee8a702b4c2d547532c12f25001c9dea795a5e631c26f1::fud::FUD',
-    decimals: 5,
-    pythFeed: '',
-    pythFeedObjectId:
-      '0x4531c3ed0d22f21f5fce882905372006c9aafa30f01db03b789e95a6c50de7b2',
-    flashloanFeeObject:
-      '0x1ddda368a5f37d7b8c53879cb333ccfd520fc4a3e2fc98b9b5fdacd1a5945d5a',
-    isolatedAssetKey:
-      '0xfcb533e9e4e31f9c9f32d6cbf7fbb3425f1d60474e229a363a2dc7f835d587e2',
-    spool: '',
-    spoolName: 'sfud',
-    spoolReward: '',
-    isIsolated: true,
-    riskModel: '',
   },
   musd: {
     coinName: 'musd',
@@ -1953,6 +2103,8 @@ export const POOL_ADDRESSES = {
       '0x340aaae070f9489b59c4257610babf6f170abf43fbe51cf7de1e2e04492f6823',
     borrowLimitKey:
       '0x2af09dd392e5fa0bb1895b021d871f42dd1bdf4843173836d9611c8c6484031a',
+    spool: '',
+    spoolReward: '',
     coinMetadataId:
       '0xc154abd271b24032a2c80d96c1b82109490bb600ed189ef881d8c9467ed44a4f',
     sCoinType:
@@ -1965,149 +2117,59 @@ export const POOL_ADDRESSES = {
     sCoinName: 'smusd',
     coinType:
       '0xe44df51c0b21a27ab915fa1fe2ca610cd3eaa6d9666fe5e62b988bf7f0bd8722::musd::MUSD',
+    spoolName: 'smusd',
     decimals: 9,
     pythFeed:
-      '2ee09cdb656959379b9262f89de5ff3d4dfed0dd34c072b3e22518496a65249c',
+      'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
     pythFeedObjectId:
-      '0x72fbf053d6009a40cff74d9708592bd7b86673a0e7b252077e1aa53390976584',
+      '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
     flashloanFeeObject:
       '0xb7da1ce9e6d5d094023147a787e973528cc339d432e5edbc9ca2ed8185cddf88',
     isolatedAssetKey:
       '0xe10f03b13d2cdb46543130bafaf1884c9a5a7712b5932aae15b2f8d4fc31a774',
-    spool: '',
-    spoolName: 'smusd',
-    spoolReward: '',
     isIsolated: true,
   },
-  fdusd: {
-    coinName: 'fdusd',
-    symbol: 'FDUSD',
+  ns: {
+    coinName: 'ns',
+    symbol: 'NS',
     lendingPoolAddress:
-      '0x4f46051a01f05c3ad9aecf29a771aad5c884e1a1888e08d7709085e3a095bc9c',
-    collateralPoolAddress:
-      '0x4f6647a9afcfdb62bb9b27e4d1cb7bd7130aca1b4f13fa7164453c869c1681ae',
-    borrowDynamic:
-      '0x4ddcf19b6290a8b048ecb314b14ef7f52c1c5b9ddc9259a2a242cd91d681a085',
-    interestModel:
-      '0xb57a33706b29d2d253c74c1c0869e6e20da99036338d2b0b7235ab41621ee9dd',
-    riskModel:
-      '0xd65fb21758dc1e6184940a1a27efb13228d7cf5e19f6dcca06cc2d996af4a6b9',
-    borrowFeeKey:
-      '0xafe673a27747b063fa918d2dfe47794e44af553737ac562c2a63186539a07f45',
-    supplyLimitKey:
-      '0x730e0785ba056a7a95f4a6959371a598d7fe782e81c40785c79982ced4cf4e35',
-    borrowLimitKey:
-      '0x1630c6954918a06fe56312afb8958366c5ed7af653dae0e32c09d088da38577e',
-    coinMetadataId:
-      '0xdebee5265a67c186ed87fe93303d33dfe1de53e3b4fd7d9329c2852860acd3e7',
-    sCoinType:
-      '0x6711551c1e7652a270d9fbf0eee25d99594c157cde3cb5fbb49035eb59b1b001::scallop_fdusd::SCALLOP_FDUSD',
-    sCoinTreasury:
-      '0xdad9bc6293e694f67a5274ea51b596e0bdabfafc585ae6d7e82888e65f1a03e0',
-    sCoinMetadataId:
-      '0xb1529a3b5e5831d19a722493eec19785f613945d3dc984602d44a418f990d73f',
-    sCoinSymbol: 'sFDUSD',
-    sCoinName: 'sfdusd',
-    coinType:
-      '0xf16e6b723f242ec745dfd7634ad072c42d5c1d9ac9d62a39c381303eaa57693a::fdusd::FDUSD',
-    decimals: 6,
-    pythFeed:
-      'ccdc1a08923e2e4f4b1e6ea89de6acbc5fe1948e9706f5604b8cb50bc1ed3979',
-    pythFeedObjectId:
-      '0x5f6583b2b0fe1ecf94aaffeaab8a838794693960cea48c0da282d5f4a24be027',
-    flashloanFeeObject:
-      '0x5e32556f5bb64358ddc9a2e9e1ec3b3053cdcbd6351e9d422058f6b9794755e1',
-    spool: '',
-    spoolName: 'sfdusd',
-    spoolReward: '',
-    isolatedAssetKey: '',
-    isIsolated: false,
-  },
-  blub: {
-    coinName: 'blub',
-    symbol: 'BLUB',
-    lendingPoolAddress:
-      '0x4dede1d8eda98647c3fc9838e94a890b73ca37a20764087eb78ba0473edea1a5',
+      '0x98491693e99905ce243655f1d2dc86b62d7c9c330985ee71d16760b63601708c',
     collateralPoolAddress: '',
     borrowDynamic:
-      '0xb2e9df6917ff3cb93fc4361102504c2d225913b3860458ef40f83b370601bec2',
+      '0x320035fc3bdba3106f550531523b5eab623fc3b42639e6b27623838d121ef64a',
     interestModel:
-      '0xec07bfcf93df52d1c0dabecc88b1ee66445a2fda6b98378c19d8e029022f2012',
+      '0x6e3c7426f922c6e8538331d36918dc092a53e46d4bb478c36d09b40d0fddc3bf',
     borrowFeeKey:
-      '0x59b820845932c1f151793b1c6e605ad993535784ccfaa83e709207d6aed3ab99',
+      '0x9d99ae707899e1034401e8fb8524573a2603ac71a6d367f65d06fbb0ca586950',
     supplyLimitKey:
-      '0xc25e930484a10498a53562cfb87da47280e842564d455f25e5b80a913002d5a0',
+      '0xe6e87903708cbc09c8d5b005ddbec036efde2c58de4b52d4d8b9f10cb5c9a92b',
     borrowLimitKey:
-      '0xaf4560140b2c6906befd546cc556f7c459964e7c31e20a6e1ab992bbc6d12b7f',
-    coinMetadataId:
-      '0xac32b519790cae96c3317457d903d61d04f1bc8f7710096d80fcba72c7a53703',
-    sCoinType:
-      '0xe72f65446eabfad2103037af2d49d24599106fb44bf4c046c1e7e9acf6844dd0::scallop_blub::SCALLOP_BLUB',
-    sCoinTreasury:
-      '0x87d34361dfd0e2accc946684d10b176484f348892f6cc51a829418040c4700e1',
-    sCoinMetadataId:
-      '0xfa11263cb39de80b9e224d7e0391866a7e779d3d62451de82a91ba601bfb1ce3',
-    sCoinSymbol: 'sBLUB',
-    sCoinName: 'sblub',
-    coinType:
-      '0xfa7ac3951fdca92c5200d468d31a365eb03b2be9936fde615e69f0c1274ad3a0::BLUB::BLUB',
-    decimals: 2,
-    pythFeed: '',
-    pythFeedObjectId:
-      '0x246658c3324f2477568c78cca622518fbc6969a004b841d81409d24a7ec39b18',
-    flashloanFeeObject:
-      '0x813176c9af63d6128e41f58ac9c02b9785c3a070a01466d1cb79de3c4691a605',
-    isolatedAssetKey:
-      '0x30a8f1dbf9dc05dae26c25fac6dfa80fa2d886e05e61cefc697b94959dd75007',
+      '0x3e958a562c6062e39559bb72feb2e4fa5595d629fcafe36a3a40546e0934bd8a',
     spool: '',
-    spoolName: 'sblub',
     spoolReward: '',
-    isIsolated: false,
-    riskModel: '',
-  },
-  sca: {
-    coinName: 'sca',
-    symbol: 'SCA',
-    lendingPoolAddress:
-      '0x6fc7d4211fc7018b6c75e7b908b88f2e0536443239804a3d32af547637bd28d7',
-    collateralPoolAddress:
-      '0xff677a5d9e9dc8f08f0a8681ebfc7481d1c7d57bc441f2881974adcdd7b13c31',
-    borrowDynamic:
-      '0x4e24f52edd739dab59ca4c6353ca430b7ce57e7f333abd0957958570a7cd09ca',
-    interestModel:
-      '0xbdcd48cf5b1a814911dc2d5c72d393a980c87820199fe5d799289ce94f4c47df',
-    riskModel:
-      '0xc437c24b67b8e2676907700fa395af337ad6463d2c0b4f4fa2e9276414026089',
-    borrowFeeKey:
-      '0xee55ba0f9800a62d9e7aef667f87e658258f41814d2c9fa02e25590671b4e5ad',
-    supplyLimitKey:
-      '0x8dd938856b972a10ea27ecab2af7ed78e48fc5f6ccedaf2b2119959f747dc2e3',
-    borrowLimitKey:
-      '0x04c7de61c5b42972f9bf6a8b1848e5fea2d037ee8deba81741ecd4a70aa80d30',
     coinMetadataId:
-      '0x5d26a1e9a55c88147ac870bfa31b729d7f49f8804b8b3adfdf3582d301cca844',
+      '0x279adec041f8ec5c2d419abf2c32713ae7930a9a3a1ff244c88e5ceced40db6e',
     sCoinType:
-      '0x5ca17430c1d046fae9edeaa8fd76c7b4193a00d764a0ecfa9418d733ad27bc1e::scallop_sca::SCALLOP_SCA',
+      '0x6511052d2f1404934e0d877709949bcda7c1d451d1218a4b2643ca2f3fa93991::scallop_ns::SCALLOP_NS',
     sCoinTreasury:
-      '0xe04bfc95e00252bd654ee13c08edef9ac5e4b6ae4074e8390db39e9a0109c529',
+      '0xa178587907006828839f312e6b5afa69e8aa9c66bdf06b2a5918bd8d913488e3',
     sCoinMetadataId:
-      '0x27e3877491b308dfac46fb3d9f7dfa6a1e8b7dc3c374e92ecda7976055746964',
-    sCoinSymbol: 'sSCA',
-    sCoinName: 'ssca',
+      '0x898320fe66409bdcf580e2a5764217aa51a6fb26890645efff7011b54117e6df',
+    sCoinSymbol: 'sNS',
+    sCoinName: 'sns',
     coinType:
-      '0x7016aae72cfc67f2fadf55769c0a7dd54291a583b63051a5ed71081cce836ac6::sca::SCA',
-    decimals: 9,
+      '0x5145494a5f5100e645e4b0aa950fa6b68f614e8c59e17bc5ded3495123a79178::ns::NS',
+    spoolName: 'sns',
+    decimals: 6,
     pythFeed:
-      '7e17f0ac105abe9214deb9944c30264f5986bf292869c6bd8e8da3ccd92d79bc',
+      'bb5ff26e47a3a6cc7ec2fce1db996c2a145300edc5acaabe43bf9ff7c5dd5d32',
     pythFeedObjectId:
-      '0xf6de1d3279a269a597d813cbaca59aa906543ab9a8c64e84a4722f1a20863985',
+      '0xea0d962a2b2cb35bbc262514ea6cfed02fdb3d5bedb193ca0d50bfefc98abebc',
     flashloanFeeObject:
-      '0xe04e46471754b6f48d81c549ecfec09de02733715a63bec02364c6ac7c4dd2dc',
-    spool: '',
-    spoolName: 'ssca',
-    spoolReward: '',
-    isolatedAssetKey: '',
-    isIsolated: false,
+      '0xdbcc132a678477fcb843212ec8b5821be5fdb6546950c230c2b4d58c6331144c',
+    isolatedAssetKey:
+      '0x73ebd841fdbe2a4b4f87fd58a729cba0a7a5871962dc04f5123339d1e0e64de8',
+    isIsolated: true,
   },
   usdy: {
     coinName: 'usdy',
@@ -2128,6 +2190,8 @@ export const POOL_ADDRESSES = {
       '0x2f3a58bcf68426cc998b7a9782dccf87351c44efbe655b13a0ac753d6f34a034',
     borrowLimitKey:
       '0xe8ade192f71fbe30d2ed1d246241c370d2882ff78ad312a3382ca8e2c73c386d',
+    spool: '',
+    spoolReward: '',
     coinMetadataId:
       '0xd8dd6cf839e2367de6e6107da4b4361f44798dd6cf26d094058d94e4cee25e36',
     sCoinType:
@@ -2140,6 +2204,7 @@ export const POOL_ADDRESSES = {
     sCoinName: 'susdy',
     coinType:
       '0x960b531667636f39e85867775f52f6b1f220a058c4de786905bdf761e06a56bb::usdy::USDY',
+    spoolName: 'susdy',
     decimals: 6,
     pythFeed:
       'e3d1723999820435ebab53003a542ff26847720692af92523eea613a9a28d500',
@@ -2147,81 +2212,6 @@ export const POOL_ADDRESSES = {
       '0x773cb390165e227cbd5bd924edaeff7d33b1b78aac045c4903ed9be7e711741a',
     flashloanFeeObject:
       '0x3088b12a808e5f54c71dc80fac922924e0e25c877c7cb78f8be7ad01f792bd2f',
-    spool: '',
-    spoolName: 'susdy',
-    spoolReward: '',
-    isolatedAssetKey: '',
-    isIsolated: false,
-  },
-  ns: {
-    coinName: 'ns',
-    symbol: 'NS',
-    lendingPoolAddress:
-      '0x98491693e99905ce243655f1d2dc86b62d7c9c330985ee71d16760b63601708c',
-    collateralPoolAddress: '',
-    borrowDynamic:
-      '0x320035fc3bdba3106f550531523b5eab623fc3b42639e6b27623838d121ef64a',
-    interestModel:
-      '0x6e3c7426f922c6e8538331d36918dc092a53e46d4bb478c36d09b40d0fddc3bf',
-    borrowFeeKey:
-      '0x9d99ae707899e1034401e8fb8524573a2603ac71a6d367f65d06fbb0ca586950',
-    supplyLimitKey:
-      '0xe6e87903708cbc09c8d5b005ddbec036efde2c58de4b52d4d8b9f10cb5c9a92b',
-    borrowLimitKey:
-      '0x3e958a562c6062e39559bb72feb2e4fa5595d629fcafe36a3a40546e0934bd8a',
-    coinMetadataId:
-      '0x279adec041f8ec5c2d419abf2c32713ae7930a9a3a1ff244c88e5ceced40db6e',
-    sCoinType:
-      '0x6511052d2f1404934e0d877709949bcda7c1d451d1218a4b2643ca2f3fa93991::scallop_ns::SCALLOP_NS',
-    sCoinTreasury:
-      '0xa178587907006828839f312e6b5afa69e8aa9c66bdf06b2a5918bd8d913488e3',
-    sCoinMetadataId:
-      '0x898320fe66409bdcf580e2a5764217aa51a6fb26890645efff7011b54117e6df',
-    sCoinSymbol: 'sNS',
-    sCoinName: 'sns',
-    coinType:
-      '0x5145494a5f5100e645e4b0aa950fa6b68f614e8c59e17bc5ded3495123a79178::ns::NS',
-    decimals: 6,
-    pythFeed:
-      'bb5ff26e47a3a6cc7ec2fce1db996c2a145300edc5acaabe43bf9ff7c5dd5d32',
-    pythFeedObjectId:
-      '0xc6352e1ea55d7b5acc3ed690cc3cdf8007978071d7bfd6a189445018cfb366e0',
-    flashloanFeeObject:
-      '0xdbcc132a678477fcb843212ec8b5821be5fdb6546950c230c2b4d58c6331144c',
-    isolatedAssetKey:
-      '0x73ebd841fdbe2a4b4f87fd58a729cba0a7a5871962dc04f5123339d1e0e64de8',
-    spool: '',
-    spoolName: 'sns',
-    spoolReward: '',
-    isIsolated: true,
-  },
-  mpoints: {
-    coinName: 'mpoints',
-    symbol: 'mPOINTS',
-    lendingPoolAddress: '',
-    collateralPoolAddress: '',
-    borrowDynamic: '',
-    interestModel: '',
-    riskModel: '',
-    borrowFeeKey: '',
-    supplyLimitKey: '',
-    borrowLimitKey: '',
-    spool: '',
-    spoolReward: '',
-    coinMetadataId:
-      '0xa06156a85117345cb3fe41146d03fe26d6c45ca16b2bc6771046814f16c60338',
-    sCoinType: '',
-    sCoinTreasury: '',
-    sCoinMetadataId: '',
-    sCoinSymbol: '',
-    sCoinName: '',
-    coinType:
-      '0x7bae0b3b7b6c3da899fe3f4af95b7110633499c02b8c6945110d799d99deaa68::mpoints::MPOINTS',
-    spoolName: '',
-    decimals: 0,
-    pythFeed: '',
-    pythFeedObjectId: '',
-    flashloanFeeObject: '',
     isolatedAssetKey: '',
     isIsolated: false,
   },
@@ -2263,7 +2253,7 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341',
     pythFeedObjectId:
-      '0xeb7e669f74d976c0b99b6ef9801e3a77716a95f1a15754e0f1399ce3fb60973d',
+      '0xdbea8600eeeb0399df58c28e73b8201ae880a954813131d33bfa6902ccdadd24',
     flashloanFeeObject:
       '0xbd3c9d957f81dfe45323b70ab2bfce8e8ef94c7940d8bc520f288119d079355a',
     isolatedAssetKey:
@@ -2281,6 +2271,8 @@ export const POOL_ADDRESSES = {
       '0x15fff8d3d331a53cc6e8461a66cb84343fceea790b135adb27e77345714bb151',
     interestModel:
       '0x717a12385920ccabe70d9cfa8a763dc0e6108482d2b0f28539ee35a2efea107c',
+    riskModel:
+      '0x6c4be92305a33e47b7d04b90e1d79eda95bfca4208ddbcdd4518bb0a01f85541',
     borrowFeeKey:
       '0x6c5bac2e5ce87ed7e4af2852abed242462efe3f8898c01b992cf1bfebb17a160',
     supplyLimitKey:
@@ -2306,14 +2298,12 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'e67d98cc1fbd94f569d5ba6c3c3c759eb3ffc5d2b28e64538a53ae13efad8fd1',
     pythFeedObjectId:
-      '0xbc98681c15de1ca1b80a8e26500d43c77f7113368b024de1bf490afcb0387109',
+      '0xcdefc25e55d4faa895874395989407d3b464fe7cf79110155c8f0a770fb9734a',
     flashloanFeeObject:
       '0xab13a86fd1bad2850d23540a208ed3327885410f9d6f950f43ea7d0ea2db927b',
     isolatedAssetKey:
       '0xefcd73fbb3d9e0a5d66aca94798a7a1d9100586482643f9fdc00993c422176c3',
     isIsolated: false,
-    riskModel:
-      '0x6c4be92305a33e47b7d04b90e1d79eda95bfca4208ddbcdd4518bb0a01f85541',
   },
   wwal: {
     coinName: 'wwal',
@@ -2353,7 +2343,7 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341',
     pythFeedObjectId:
-      '0xeb7e669f74d976c0b99b6ef9801e3a77716a95f1a15754e0f1399ce3fb60973d',
+      '0xdbea8600eeeb0399df58c28e73b8201ae880a954813131d33bfa6902ccdadd24',
     flashloanFeeObject:
       '0x1ddfa11a167384bce721508cca8a8d6592cae3252aca321704ad16a32f1c0db5',
     isolatedAssetKey: '',
@@ -2397,54 +2387,11 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'eba0732395fae9dec4bae12e52760b35fc1c5671e2da8b449c9af4efe5d54341',
     pythFeedObjectId:
-      '0xeb7e669f74d976c0b99b6ef9801e3a77716a95f1a15754e0f1399ce3fb60973d',
+      '0xdbea8600eeeb0399df58c28e73b8201ae880a954813131d33bfa6902ccdadd24',
     flashloanFeeObject:
       '0x36501a7c2fc3429bfb3326b3f00675f308a369f77c7d73e722258f1be14b297e',
     isolatedAssetKey: '',
     isIsolated: false,
-  },
-  lofi: {
-    coinName: 'lofi',
-    symbol: 'LOFI',
-    lendingPoolAddress:
-      '0x186a998dd93384fad43711ab99417a4c0b5223a5c6759483c786397d43d60d79',
-    collateralPoolAddress: '',
-    borrowDynamic:
-      '0x901b6ba37a43e51ac4a544c75a7fae890d9c2fc0d24d5e6ecb58ec86e4446cb4',
-    interestModel:
-      '0x9aae55d520587530464520820e53be6b256c5b19108d62807b5dce626b8a90cd',
-    riskModel: '',
-    borrowFeeKey:
-      '0x9bc2a2db2b5908cbd736e54233db674929cbce36753311db3298aa756e412cb3',
-    supplyLimitKey:
-      '0x0d497d3680b2517ce37b3326cb874f5c2dab6007457fe86e2ccee2a891adcddb',
-    borrowLimitKey:
-      '0x077722075b388c38f03b638831ae0619a4d277f8c95bbf925c87296753b01715',
-    spool: '',
-    spoolReward: '',
-    coinMetadataId:
-      '0x57a2bf5e6887eca522fe6c3ff0d9d8dc116d072998a477c6c24fe6603107ebb8',
-    sCoinType:
-      '0x7eb699b346f752cf50a348b015fcaafa00224f88b8c2391a7cba1153ccdb91f9::scallop_lofi::SCALLOP_LOFI',
-    sCoinTreasury:
-      '0xd5057447ac659ab3c50fa9cf444ac87a8086f198070b2b47b1e72630d1315c23',
-    sCoinMetadataId:
-      '0xb55c74ac7302805a8c11a8c1328cae79d04c7484c5efd05b937ab9fd90602277',
-    sCoinSymbol: 'sLOFI',
-    sCoinName: 'slofi',
-    coinType:
-      '0xf22da9a24ad027cccb5f2d496cbe91de953d363513db08a3a734d361c7c17503::LOFI::LOFI',
-    spoolName: 'slofi',
-    decimals: 9,
-    pythFeed:
-      '82eebc2c47490ba9c0f9bc35ea9fb57a7e2bbf69b84a04ea2a3525153b8090ea',
-    pythFeedObjectId:
-      '0xb65b2888e74b2be973616740da410670ecd6d1d1f4b5456acc7b04ece9c95559',
-    flashloanFeeObject:
-      '0xe048cb922fc7234a3e1d4f2b2255b8bd0b990d0693db8100c0035a1dce1eebdc',
-    isolatedAssetKey:
-      '0x2553f563dca4e22c8e47223d97f53498b7ce4929452bb97637b119787c901528',
-    isIsolated: true,
   },
   xbtc: {
     coinName: 'xbtc',
@@ -2484,7 +2431,7 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
     pythFeedObjectId:
-      '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+      '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
     flashloanFeeObject:
       '0xec9edb6fd55666069331b1ac43ecf1e94fb1a972c5124d82369967520007cb8e',
     isolatedAssetKey: '',
@@ -2528,7 +2475,7 @@ export const POOL_ADDRESSES = {
     pythFeed:
       'e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43',
     pythFeedObjectId:
-      '0x9a62b4863bdeaabdc9500fce769cf7e72d5585eeb28a6d26e4cafadc13f76ab2',
+      '0xe64832d1b4c9a75139a7313aee69da891297d8397fda2863b5bdcc4af0b79758',
     flashloanFeeObject:
       '0x263f69c0da8f7f0c52a5bc81816c1dfc6bf92c2c6e808a140a901aebe142bd21',
     isolatedAssetKey: '',
@@ -2566,10 +2513,12 @@ export const POOL_ADDRESSES = {
     sCoinName: 'ssuiusde',
     coinType:
       '0x41d587e5336f1c86cad50d38a7136db99333bb9bda91cea4ba69115defeb1402::sui_usde::SUI_USDE',
-    spoolName: '',
+    spoolName: 'ssuiusde',
     decimals: 6,
-    pythFeed: '',
-    pythFeedObjectId: '',
+    pythFeed:
+      'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
+    pythFeedObjectId:
+      '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
     flashloanFeeObject:
       '0xfdadb716b4a67da2b498d24bcd8e0ccc6940286616f1dbc10b150620e10d0d12',
     isolatedAssetKey: '',
@@ -2603,16 +2552,16 @@ export const POOL_ADDRESSES = {
       '0xba68a930f4f35b589071e1247c44ada1c5e28cb3fac437b2cc6f8d9491c3b4bb',
     sCoinMetadataId:
       '0xbdd57e96225140e42fccf5d357a7f1ebb42d4fe47ceb50cc99f5d02cd72fb5b1',
-    sCoinSymbol: 'sUSDsui',
+    sCoinSymbol: 'sUSDSUI',
     sCoinName: 'susdsui',
     coinType:
       '0x44f838219cf67b058f3b37907b655f226153c18e33dfcd0da559a844fea9b1c1::usdsui::USDSUI',
-    spoolName: '',
+    spoolName: 'susdsui',
     decimals: 6,
     pythFeed:
       'eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a',
     pythFeedObjectId:
-      '0x5dec622733a204ca27f5a90d8c2fad453cc6665186fd5dff13a83d0b6c9027ab',
+      '0x6ddfc6f9921e55998cbc2e68f78eba897981d79ac17f66c5277bc38954a2a3f8',
     flashloanFeeObject:
       '0xd60ece53f1d9dc59c0badbebe117e1a86ccfc461625a11d4d68aee95af0a06c6',
     isolatedAssetKey: '',
@@ -2651,14 +2600,58 @@ export const POOL_ADDRESSES = {
     sCoinName: 'sxaum',
     coinType:
       '0x9d297676e7a4b771ab023291377b2adfaa4938fb9080b8d12430e4b108b836a9::xaum::XAUM',
-    spoolName: '',
+    spoolName: 'sxaum',
     decimals: 9,
     pythFeed:
       'd7db067954e28f51a96fd50c6d51775094025ced2d60af61ec9803e553471c88',
     pythFeedObjectId:
-      '0x2731a8e3e9bc69b2d6af6f4c032fcd4856c77e2c21f839134d1ebcc3a16e4b1b',
+      '0xb81afb56abc903ce2c6f7e96fa8fbe3fc66d4ed9dbd9027a7d16d15dca387366',
     flashloanFeeObject:
       '0x1decb25a210661bad9f277868eea9fc9467227e088d272e65b234404f9df28aa',
+    isolatedAssetKey: '',
+    isIsolated: false,
+  },
+  scasui: {
+    coinName: 'scasui',
+    symbol: 'scaSUI',
+    lendingPoolAddress:
+      '0xe9c230afa7d072eee4deb84dc839e1aaf3ab5c15b724a36c600bcfea392834f1',
+    collateralPoolAddress:
+      '0xe196494f4c84321aff5de474fd2eea34af8a5cb4893cca92b86ccb2dc6c095c8',
+    borrowDynamic:
+      '0xe9ccbb67e6f775b173541f9218ec184786d06bfe2d67b8dce91a5b60e177a327',
+    interestModel:
+      '0x10089ad063a14e42cc0e98a0c82690892136dcf290167a2e8b5b4ffb8290f4e8',
+    riskModel:
+      '0xaac0d9e3a6d774e1602a2c30921dce0e07be5ab9a5d56aad00eb7a78e8298db6',
+    borrowFeeKey:
+      '0xcbb98271298b03ec30c5cdb68310736dbbb6e0f56aace2745e988bd49b4eea15',
+    supplyLimitKey:
+      '0x3db53e8c990a1c1d8196d71026847e84af32cbe5e678c476770c7b1b3a09651a',
+    borrowLimitKey:
+      '0xfcb49e2bcee1ce8d16a36e31fd6c06fd26d2e425232e24735d4c678ccf06461c',
+    spool: '',
+    spoolReward: '',
+    coinMetadataId:
+      '0x71dd901768abcd6e83c4bca76dc7b45fe1ef038c554eba4b1fd76a4c5d91703d',
+    sCoinType:
+      '0xa3b4ce56e020cb8086b38fb042b763ccfa1518a43715fb21673a7d814f6e2dac::scallop_sca_sui::SCALLOP_SCA_SUI',
+    sCoinTreasury:
+      '0x85733627f015ac4f76b198235670f274a44241911623b7c695c784e95afc39bc',
+    sCoinMetadataId:
+      '0xbc36b58fae4e614d5d2614ada71e61e667924351e0ecc4682421a67b5a41ae64',
+    sCoinSymbol: 'sscaSUI',
+    sCoinName: 'sscasui',
+    coinType:
+      '0xda008a552a2d6a9566fa6204255d55ab32ce00f23e307145dec2644cf83336b2::sca_sui::SCA_SUI',
+    spoolName: 'sscasui',
+    decimals: 9,
+    pythFeed:
+      '23d7315113f5b1d3ba7a83604c44b94d79f4fd69af77f804fc7f920a6dc65744',
+    pythFeedObjectId:
+      '0x89b2add829cb6fcd017153fff428bc9faec4d06d643ecfc435af5b55a9e987f0',
+    flashloanFeeObject:
+      '0xe293a16bd0248796f79e4d252aee3b7ad550520c41c4cf4a68f41d567c8e5a2c',
     isolatedAssetKey: '',
     isIsolated: false,
   },
@@ -2691,13 +2684,15 @@ export const WHITELIST = {
     'usdy',
     'wal',
     'haedal',
-    'hawal',
     'wwal',
+    'hawal',
     'xbtc',
     'zwbtc',
     'suiusde',
     'usdsui',
     'xaum',
+    'scasui',
+    // 'lofi'
   ],
   collateral: [
     'usdc',
@@ -2720,12 +2715,14 @@ export const WHITELIST = {
     'usdy',
     'wal',
     'deep',
-    'hawal',
+    // 'haedal',
     'wwal',
+    'hawal',
     'xbtc',
     'zwbtc',
     'usdsui',
     'xaum',
+    'scasui',
   ],
   borrowing: [
     'usdc',
@@ -2753,12 +2750,15 @@ export const WHITELIST = {
     'usdy',
     'wal',
     'haedal',
-    'hawal',
     'wwal',
+    'hawal',
     'xbtc',
     'zwbtc',
+    'suiusde',
     'usdsui',
     'xaum',
+    'scasui',
+    // 'lofi'
   ],
   packages: [
     'coinDecimalsRegistry',
@@ -2817,18 +2817,15 @@ export const WHITELIST = {
     'ssuiusde',
     'susdsui',
     'sxaum',
+    'scasui',
+    // 'slofi',
   ],
   suiBridge: ['sbeth', 'sbusdt', 'sbwbtc'],
   wormhole: ['wusdc', 'wusdt', 'weth', 'wbtc', 'wapt', 'wsol'],
+  layerZero: ['zwbtc'],
   oracles: ['pyth', 'supra', 'switchboard'],
-  pythEndpoints: [
-    'https://pyth.dourolabs.app/hermes',
-    'https://scallop.rpc.p2p.world',
-  ],
-  createdAt: '2025-03-11T20:50:11.000Z',
-  updatedAt: '2026-03-15T19:46:54.483Z',
-  version: 0,
-  deprecated: ['wapt', 'wusdc', 'wusdt', 'weth', 'wbtc', 'vsui', 'fud', 'blub'],
+  pythEndpoints: ['https://pyth.dourolabs.app/hermes'],
+  deprecated: ['wapt', 'wusdc', 'wusdt', 'weth', 'wbtc', 'vsui', 'fud'],
   borrowIncentiveRewards: ['mpoints'],
   rewardsAsPoint: ['mpoints'],
   emerging: [
@@ -2837,11 +2834,9 @@ export const WHITELIST = {
     'sca',
     'cetus',
     'haedal',
+    'blub',
     'wwal',
     'hawal',
     'usdsui',
-    'xaum',
   ],
-  layerZero: ['zwbtc'],
-  id: '67d0a6659b2f19676efffe78',
 };

--- a/tests/scallopSdk.ts
+++ b/tests/scallopSdk.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 import { NetworkType } from '@scallop-io/sui-kit';
 import { Scallop } from 'src/entries/index.js';
-import { ADDRESS_INTERFACE, POOL_ADDRESSES, WHITELIST } from './mocks.js';
+import { ADDRESSES, POOL_ADDRESSES, WHITELIST } from './mocks.js';
 dotenv.config();
 
 const NETWORK: NetworkType = 'mainnet';
@@ -9,7 +9,7 @@ export const scallopSDK = new Scallop({
   addressId: '695fcdc084f790c04eb068dc',
   secretKey: process.env.SECRET_KEY,
   network: NETWORK,
-  forceAddressesInterface: ADDRESS_INTERFACE,
+  forceAddressesInterface: ADDRESSES,
   forcePoolAddressInterface: POOL_ADDRESSES,
   forceWhitelistInterface: WHITELIST,
   // pythEndpoints: ['https://pyth.dourolabs.app/hermes'],
@@ -30,7 +30,7 @@ export const graphQLScallopSDK = new Scallop({
   addressId: '695fcdc084f790c04eb068dc',
   secretKey: process.env.SECRET_KEY,
   network: NETWORK,
-  forceAddressesInterface: ADDRESS_INTERFACE,
+  forceAddressesInterface: ADDRESSES,
   forcePoolAddressInterface: POOL_ADDRESSES,
   forceWhitelistInterface: WHITELIST,
   pythEndpoints: ['https://hermes.pyth.network'],

--- a/tests/strictInit.spec.ts
+++ b/tests/strictInit.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import ScallopConstants from 'src/models/scallopConstants/index.js';
 import { ScallopConfigError } from 'src/errors/index.js';
-import { ADDRESS_INTERFACE, POOL_ADDRESSES, WHITELIST } from './mocks.js';
+import { ADDRESSES, POOL_ADDRESSES, WHITELIST } from './mocks.js';
 
 const queryClientConfig = {
   defaultOptions: {
@@ -14,7 +14,7 @@ describe('ScallopConstants strict-init', () => {
     const constants = new ScallopConstants({
       addressId: '695fcdc084f790c04eb068dc',
       network: 'mainnet',
-      forceAddressesInterface: ADDRESS_INTERFACE,
+      forceAddressesInterface: ADDRESSES,
       forcePoolAddressInterface: POOL_ADDRESSES,
       forceWhitelistInterface: WHITELIST,
       strictInit: true,
@@ -30,7 +30,7 @@ describe('ScallopConstants strict-init', () => {
     const constants = new ScallopConstants({
       addressId: '695fcdc084f790c04eb068dc',
       network: 'mainnet',
-      forceAddressesInterface: ADDRESS_INTERFACE,
+      forceAddressesInterface: ADDRESSES,
       forcePoolAddressInterface: POOL_ADDRESSES,
       forceWhitelistInterface: WHITELIST,
       queryClientConfig,
@@ -51,9 +51,9 @@ describe('ScallopConstants strict-init', () => {
   it('init() throws ScallopConfigError when a required core path is empty', async () => {
     const brokenAddresses = {
       mainnet: {
-        ...ADDRESS_INTERFACE.mainnet,
+        ...ADDRESSES.mainnet,
         core: {
-          ...ADDRESS_INTERFACE.mainnet.core,
+          ...ADDRESSES.mainnet.core,
           market: '',
         },
       },
@@ -86,9 +86,9 @@ describe('ScallopConstants strict-init', () => {
   it('init() does not throw on incomplete config when strictInit is false', async () => {
     const brokenAddresses = {
       mainnet: {
-        ...ADDRESS_INTERFACE.mainnet,
+        ...ADDRESSES.mainnet,
         core: {
-          ...ADDRESS_INTERFACE.mainnet.core,
+          ...ADDRESSES.mainnet.core,
           market: '',
         },
       },


### PR DESCRIPTION
## [5.2.5](https://github.com/scallop-io/sui-scallop-sdk/compare/v5.2.4...v5.2.5) (2026-08-01)

### Fixed

- The borrow-incentive pool query used the raw on-chain `pool_type` field (which can be an object) instead of the parsed pool type, and silently dropped point updates once a reward campaign was exhausted instead of still emitting the accrued points with a zeroed APR ([c5d68c0](https://github.com/scallop-io/sui-scallop-sdk/commit/c5d68c08584a814158e1266939643c0e8237f9e3))
